### PR TITLE
Thanos to the latest version, where they have better performance

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -369,7 +369,7 @@ prometheus:
 
     thanos: 
       baseImage: quay.io/thanos/thanos
-      version: v0.10.1
+      version: v0.11.0
       objectStorageConfig:
         key: thanos.yaml
         name: thanos-objstore-config 


### PR DESCRIPTION
Deploying the latest version of Thanos container (v0.11.0). They improved performance (and much more things, complete list [here](https://github.com/thanos-io/thanos/blob/master/CHANGELOG.md#v0110---20200302)) and hopefully can help us to manage the memory overload.