### PR TITLE
Updating cloudwatch timeout: 60s

### DIFF
--- a/resources/cloudwatch-exporter.yaml
+++ b/resources/cloudwatch-exporter.yaml
@@ -234,4 +234,4 @@ serviceMonitor:
   labels:
     app: prometheus-cloudwatch-exporter
   # Set timeout for scrape
-  timeout: 30s
+  timeout: 60s


### PR DESCRIPTION
As it is giving "Context Deadline Exceeded" error for cloud-watch in prometheus.