### PR TITLE
Add warning nginx reload failure and increase critical alert threshold to 5 mins 

### DIFF
--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -114,12 +114,20 @@ spec:
       annotations:
         message: HTTPCode_Target_5XX_Count high for `{{$labels.service}}. HTTPCode_Target_5XX_Count high'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md
+    - alert: NginxConfigReloadFailureWarning
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginx-config-reload-failure
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 3m
+      labels:
+        severity: warning
     - alert: NginxConfigReloadFailure
       annotations:
         message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginx-config-reload-failure
       expr: nginx_ingress_controller_config_last_reload_successful == 0
-      for: 1m
+      for: 5m
       labels:
         severity: critical
         


### PR DESCRIPTION
WHAT
Increase critical failure wait time to 5 mins and add a warning error for 3 mins to go to low priority alarms

WHY
We have had a number of triggers for this alarm, which have resolved by itself. Nginx resolves the error by correcting the config compared to the other ingress controller pods. This trigger was set to 1 min, therefor triggering before nginx can resolve. New alert will trigger after 3 mins and high priority critical after 5 mins. 