### PR TITLE
add 4 new KubeAPILatency alerts - separating out ingress post alerts …from the others

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -9,6 +9,56 @@ spec:
   groups:
   - name: kubernetes-apps
     rules:
+    - alert: KubeAPILatencyWarning
+      annotations:
+        message: The API server has an abnormal latency of {{ $value }} seconds for {{ $labels.verb
+          }} {{ $labels.resource }}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
+      expr: |-
+        (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver",resource!="ingresses",verb!="POST"}
+        > on(verb) group_left() (avg by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0) + 2 * stddev by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0))) > on(verb) group_left() 1.2 * avg by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0) and on(verb, resource) cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99"}
+        > 1
+      for: 5m
+      labels:
+        severity: warning
+    - alert: KubeAPILatencyCritical
+      annotations:
+        message: The API server has a 99th percentile latency of {{ $value }} seconds for
+          {{ $labels.verb }} {{ $labels.resource }}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
+      expr: |-
+        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",resource!="ingresses",verb!="POST"} > 4
+      for: 10m
+      labels:
+        severity: critical
+    - alert: KubeAPILatencyWarning-IngressPost
+      annotations:
+        message: The API server has an abnormal latency of {{ $value }} seconds for {{ $labels.verb
+          }} {{ $labels.resource }}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
+      expr: |-
+        (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver",resource="ingresses",verb="POST"}
+        > on(verb) group_left() (avg by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0) + 2 * stddev by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0))) > on(verb) group_left() 1.2 * avg by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
+        >= 0) and on(verb, resource) cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99"}
+        > 10
+      for: 5m
+      labels:
+        severity: warning
+    - alert: KubeAPILatencyCritical-IngressPost
+      annotations:
+        message: The API server has a 99th percentile latency of {{ $value }} seconds for
+          {{ $labels.verb }} {{ $labels.resource }}.
+        runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
+      expr: |-
+        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",resource="ingresses",verb="POST"} > 30
+      for: 10m
+      labels:
+        severity: critical
     - alert: KubeQuota-Exceeded
       annotations:
         message: Namespace {{ $labels.namespace }} is using {{ printf "%0.0f" $value


### PR DESCRIPTION
Why:
[Update "KubeAPILatencyHigh" Alerts#1797](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/1797)
[Investigate the high KubeAPILatencyHigh alarms#1717](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/1717)

4 custom alerts created:
2 - warning (1 for IngressPost KubeAPILatency alerts, 1 for remaining KubeAPILatency alerts
2 - critical (1 for IngressPost KubeAPILatency alerts, 1 for remaining KubeAPILatency alerts

Ingress alerts set to :

-  over 10 seconds for 5minutes , warning

-   over 30 seconds for 10minutes , warning

To do - Update run-book with  custom alerts description and change run-book links here
 