### PR TITLE
Silence high latency alarms as new custom alerts created

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -49,6 +49,9 @@ alertmanager:
       - match:
           alertname: PrometheusTargetScrapesDuplicate
         receiver: 'null'
+      - match:
+          alertname: KubeAPILatencyHigh
+        receiver: 'null'
       
       - match:
           severity: critical


### PR DESCRIPTION
WHAT
Silence default api high latency alarm 

WHY
We have new custom alerts for this that separates out ingress post api calls with longer trigger values and new alarms for all other api calls 