### PR TITLE
Migrating metrics server to the monitoring module

### DIFF
--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -1,0 +1,30 @@
+
+resource "helm_release" "metrics_server" {
+  name       = "metrics-server"
+  chart      = "metrics-server"
+  repository = data.helm_repository.stable.metadata[0].name
+  namespace  = "kube-system"
+  version    = "2.8.8"
+
+  depends_on = [null_resource.deploy]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+
+  set {
+    name  = "args[0]"
+    value = "--kubelet-insecure-tls"
+  }
+
+  set {
+    name  = "args[1]"
+    value = "--kubelet-preferred-address-types=InternalIP"
+  }
+
+  set {
+    name  = "hostNetwork.enabled"
+    value = "true"
+  }
+
+}

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -6,7 +6,7 @@ resource "helm_release" "metrics_server" {
   namespace  = "kube-system"
   version    = "2.8.8"
 
-  depends_on = [null_resource.deploy]
+  depends_on = [var.dependence_deploy]
 
   lifecycle {
     ignore_changes = [keyring]


### PR DESCRIPTION
This PR moves metrics-server terraform helm resource into the monitoring module, it looks more related to monitoring and useful to be within a module. 

