### PR TITLE
Mute AggregatedAPIDown alarm

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -42,6 +42,9 @@ alertmanager:
           alertname: DeadMansSwitch
         receiver: 'null'
       - match:
+          alertname: AggregatedAPIDown
+        receiver: 'null'
+      - match:
           alertname: DeploymentReplicasAreOutdated
         receiver: 'null'
       - match:


### PR DESCRIPTION
This mutes AggregatedAPIDown, which get triggered in the latest Prometheus Operator upgrade we did for the Helm Chart.

As you can see in https://github.com/helm/charts/issues/22278 and https://github.com/kubernetes-monitoring/kubernetes-mixin/issues/397 looks to be happening for k8s versions < 1.18