### PR TITLE
Fixed conditional in order to avoid empty tuple

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -306,7 +306,7 @@ module "iam_assumable_role_grafana_datasource" {
   create_role                   = var.eks ? true : false
   role_name                     = "datasource-test.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks ? aws_iam_policy.grafana_datasource.0.arn : "" ]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.grafana_datasource) >= 1 ? aws_iam_policy.grafana_datasource.0.arn : "" ]
   oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-operator-grafana"]
 }
 

--- a/thanos.tf
+++ b/thanos.tf
@@ -98,7 +98,7 @@ module "iam_assumable_role_monitoring" {
   create_role                   = var.eks ? true : false
   role_name                     = "monitoring.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.eks ? aws_iam_policy.monitoring.0.arn : ""]
+  role_policy_arns              = [var.eks && length(aws_iam_policy.monitoring) >= 1 ? aws_iam_policy.monitoring.0.arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-operator-prometheus"]
 }
 


### PR DESCRIPTION
Otherwise, we face in EKS:

```
Error: Invalid index

  on .terraform/modules/monitoring/prometheus.tf line 309, in module "iam_assumable_role_grafana_datasource":
 309:   role_policy_arns              = [var.eks ? aws_iam_policy.grafana_datasource.0.arn : "" ]
    |----------------
    | aws_iam_policy.grafana_datasource is empty tuple

The given key does not identify an element in this collection value.


Error: Invalid index

  on .terraform/modules/monitoring/thanos.tf line 101, in module "iam_assumable_role_monitoring":
 101:   role_policy_arns              = [var.eks ? aws_iam_policy.monitoring.0.arn : ""]
    |----------------
    | aws_iam_policy.monitoring is empty tuple

The given key does not identify an element in this collection value.
```

NOTE: This change only applies to EKS