### PR TITLE
Deleted dependence_deploy variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ module "monitoring" {
   oidc_components_client_secret = data.terraform_remote_state.cluster.outputs.oidc_components_client_secret
   oidc_issuer_url               = data.terraform_remote_state.cluster.outputs.oidc_issuer_url
 
-  dependence_deploy = null_resource.deploy
   dependence_opa    = module.opa.helm_opa_status
 }
 ```
@@ -36,7 +35,6 @@ module "monitoring" {
 | enable_thanos                | Enable or not Thanos                                    | bool   | false | no |
 | enable_ecr_exporter          | Conditional to deploy ECR Exporter                      | bool   | false | no |
 | enable_cloudwatch_exporter   | Conditional to deploy CloudWatch Exporter               | bool   | false | no |
-| dependence_deploy            | Dependency on helm                                      | string | | yes |
 | dependence_opa               | The key_pair name to be used in the bastion instance    | string | | yes |
 | cluster_domain_name          | Value used by externalDNS and certmanager               | string | | yes |
 | oidc_components_client_id    | OIDC ClientID used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | string | | yes |

--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -28,7 +28,6 @@ resource "helm_release" "ecr_exporter" {
   }
 
   depends_on = [
-    var.dependence_deploy,
     helm_release.prometheus_operator,
   ]
 

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -6,8 +6,6 @@ resource "helm_release" "metrics_server" {
   namespace  = "kube-system"
   version    = "2.8.8"
 
-  depends_on = [var.dependence_deploy]
-
   lifecycle {
     ignore_changes = [keyring]
   }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -138,7 +138,6 @@ resource "helm_release" "prometheus_operator" {
 
   # Depends on Helm being installed
   depends_on = [
-    var.dependence_deploy,
     var.dependence_opa,
     kubernetes_secret.grafana_secret,
     kubernetes_secret.thanos_config,
@@ -196,7 +195,6 @@ resource "helm_release" "prometheus_proxy" {
   ]
 
   depends_on = [
-    var.dependence_deploy,
     var.dependence_opa,
     random_id.session_secret,
   ]
@@ -236,7 +234,6 @@ resource "helm_release" "alertmanager_proxy" {
   ]
 
   depends_on = [
-    var.dependence_deploy,
     var.dependence_opa,
     random_id.session_secret,
   ]

--- a/variables.tf
+++ b/variables.tf
@@ -1,4 +1,3 @@
-
 variable "alertmanager_slack_receivers" {
   description = "A list of configuration values for Slack receivers"
   type        = list
@@ -11,10 +10,6 @@ variable "iam_role_nodes" {
 
 variable "pagerduty_config" {
   description = "Add PagerDuty key to allow integration with a PD service."
-}
-
-variable "dependence_deploy" {
-  description = "Deploy Module dependences in order to be executed."
 }
 
 variable "dependence_opa" {


### PR DESCRIPTION
This variable was needed when we were using Helm 2, it was the way to tell Helm Chart inside our terraform modules to wait for tiller before getting installed.

Now we are using Helm 3 and there is not tiller in the clusters.