### PR TITLE
Upgrade grafana to 7.0.2

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -165,6 +165,11 @@ alertmanager:
 grafana:
   enabled: true
 
+  image:
+    repository: grafana/grafana
+    tag: 7.0.2
+    pullPolicy: IfNotPresent
+
 %{ if eks ~}
   serviceAccount:
     create: true


### PR DESCRIPTION
This is due to Grafana 7.0.2 released with important security fix

https://grafana.com/blog/2020/06/03/grafana-6.7.4-and-7.0.2-released-with-important-security-fix/?utm_source=grafana_news&utm_medium=rss