### PR TITLE
Update NginxIngressPodDown alerts - incorrect info returned

### DIFF
--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -58,37 +58,32 @@ spec:
         message: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#kubednsdown
     - alert: NginxIngressPodDown
-      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} <6
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"^nginx-ingress-acme-controller.*"})> 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-ingress pods have been unavailable for 5 minutes'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+
     - alert: NginxIngressDown
-      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-controller"} == 0
+      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"^nginx-ingress-acme-controller.*"})> 5
       for: 5m
       labels:
         severity: critical
       annotations:
-        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-ingress has been down for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
-    - alert: NginxAcmeIngressPodDown
-      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} <6
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
+
+    - alert: NginxIngressPodPending
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"^nginx-ingress-acme-controller.*"})> 0
       for: 5m
       labels:
         severity: warning
       annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-acme-ingress pods have been unavailable for 5 minutes'
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. 1 or more nginx-ingress pods have been unavailable for 5 minutes'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingresspoddown
-    - alert: NginxAcmeIngressDown
-      expr: kube_deployment_status_replicas_available{deployment="nginx-ingress-acme-controller"} == 0
-      for: 5m
-      labels:
-        severity: critical
-      annotations:
-        descrition: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace. nginx-acme-ingress has been down for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/blob/master/terraform/cloud-platform-components/resources/prometheusrule-alerts/Custom-Alerts.md#nginxingressdown
+
     - alert: RootVolUtilisation-High
       expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
       for: 5m


### PR DESCRIPTION
Why:
[Amend nginx alarm to show which pod has failed#2188](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2188):

"kube_deployment_status_replicas_available" - always seems to return information concerning the prometheus pod rather than the "ingress-controllers" pod - which is actually the one that has gone down/failed etc. See here for example https://mojdt.slack.com/archives/C8QR5FQRX/p1596764130004800

I have included:

-  alert for warning - when 1 or more pods have "failed" (sum by pod).

-  alert for warning - when 1 pods have "pending" or "unknown" status (sum by pod).

-  alert for critical - when more than 5 pods have "failed" (sum by namespace).



