### PR TITLE
Bump latency for ingress post alarm

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -45,7 +45,7 @@ spec:
         >= 0) + 2 * stddev by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
         >= 0))) > on(verb) group_left() 1.2 * avg by(verb) (cluster:apiserver_request_duration_seconds:mean5m{job="apiserver"}
         >= 0) and on(verb, resource) cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99"}
-        > 17
+        > 30
       for: 5m
       labels:
         severity: warning
@@ -55,7 +55,7 @@ spec:
           {{ $labels.verb }} {{ $labels.resource }}.
         runbook_url: https://github.com/kubernetes-monitoring/kubernetes-mixin/tree/master/runbook.md#alert-name-kubeapilatencyhigh
       expr: |-
-        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",resource="ingresses",verb="POST"} > 30
+        cluster_quantile:apiserver_request_duration_seconds:histogram_quantile{job="apiserver",quantile="0.99",resource="ingresses",verb="POST"} > 50
       for: 10m
       labels:
         severity: critical


### PR DESCRIPTION
The ingress-post API latency alarm triggers on a regular occurrence.
This happens because of the great load we place on our load balancers.To
fix this all teams in the cluster will get there own ingress
controllers, with their own load balancers.

As this work will take a while to adopt, it is necessary for us to
increase the warning aspect of this alarm to 30, which in turn will mean
increasing the critical alarm to 50.