### PR TITLE
Explicitly specified which ingress controller to use.

### DIFF
--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -34,13 +34,8 @@ ingress:
     - hosts:
       - "${hostname}"
 
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: "true"
-
-  # annotations:
-  #   kubernetes.io/ingress.class: nginx
-  #   kubernetes.io/tls-acme: "true"
+  annotations:
+    kubernetes.io/ingress.class: monitoring
   tls:
     - hosts:
       - "${hostname}"

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -187,9 +187,9 @@ grafana:
 %{ endif ~}
 
   ingress:
-    ## If true, Prometheus Ingress will be created
-    ##
     enabled: true
+    annotations: 
+      kubernetes.io/ingress.class: monitoring
 
     hosts:
     - "${ grafana_ingress }"


### PR DESCRIPTION
Specified a custom annotation within ingress metadata in order to force them the use of monitoring ingress controller rather than the default one