### PR TITLE
Removed ingress classes, we want to use the default ingress controller

### DIFF
--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -28,8 +28,6 @@ extraArgs:
 ingress:
   enabled: true
   path: /
-  annotations:
-    kubernetes.io/ingress.class: monitoring
   hosts:
     - "${hostname}"
   tls:

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -188,8 +188,6 @@ grafana:
 
   ingress:
     enabled: true
-    annotations: 
-      kubernetes.io/ingress.class: monitoring
     hosts:
     - "${ grafana_ingress }"
     tls:


### PR DESCRIPTION
As we discussed in the SU, we agreed all traffic should go through the default ingress controller.
