### PR TITLE
Bump prometheus and alertmanager chart proxies to 3.2.2

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -188,7 +188,7 @@ resource "helm_release" "prometheus_proxy" {
   namespace  = kubernetes_namespace.monitoring.id
   repository = data.helm_repository.stable.metadata[0].name
   chart      = "oauth2-proxy"
-  version    = "2.4.1"
+  version    = "3.2.2"
 
   values = [
     data.template_file.prometheus_proxy.rendered,
@@ -227,7 +227,7 @@ resource "helm_release" "alertmanager_proxy" {
   namespace  = "monitoring"
   repository = data.helm_repository.stable.metadata[0].name
   chart      = "oauth2-proxy"
-  version    = "2.4.1"
+  version    = "3.2.2"
 
   values = [
     data.template_file.alertmanager_proxy.rendered,

--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -33,3 +33,6 @@ ingress:
   tls:
     - hosts:
       - "${hostname}"
+
+serviceAccount:
+  enabled: false


### PR DESCRIPTION
Breaking changes outlined in this README:
https://github.com/helm/charts/tree/master/stable/oauth2-proxy#to-300

This requires us to specify that we don't want to enable a service
account from IAM.

This PR connects to https://github.com/ministryofjustice/cloud-platform/issues/2078