### PR TITLE
New Prometheus, new OIDC Proxy and Remove kubeDNS checks.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ module "monitoring" {
 | oidc_components_client_id    | OIDC ClientID used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | string | | yes |
 | oidc_components_client_secret | OIDC ClientSecret used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | string | | yes |
 | oidc_issuer_url              | Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | string | | yes |
+| split_prometheus             | Create another prometheus instance to look only for the infrastructure labels (more info below in this readme) | true | | false |
 | eks                          | Are we deploying in EKS or not?                                                       | bool     | false   | no |
 | eks_cluster_oidc_issuer_url  | The OIDC issuer URL from the cluster, it is used for IAM ServiceAccount integration   | string     |  | no |
 
@@ -48,3 +49,12 @@ module "monitoring" {
 | Name | Description |
 |------|-------------|
 | helm_prometheus_operator_status | This is an output used as a dependency (to know the prometheus-operator chart has been deployed) |
+
+## Split Prometheus
+
+Our [big monolithic Prometheus](https://prometheus.cloud-platform.service.justice.gov.uk) (live-1) is having performance issues evaluating Rules. Some of the rules (kube-api) are having non-deterministic evaluation times up to 60 seconds, which causes the trigger of `PrometheusMissingRuleEvaluations` alert multiple times in #lower-priority-alarm.
+
+In order to solve the described problem, it was added `split_prometheus` terraform variable. When set to `true` it:
+- It set up the [big monolithic Prometheus](https://prometheus.cloud-platform.service.justice.gov.uk) to *only match* rules having `prometheus: cloud-platform` labels (which all teams rules have).
+- Create a new Prometheus instance *only matching* the rules having `release: prometheus-operator`. These are the default rules from prometheus-operator Helm Chart to scan and keep the cluster healthy. Unfortunately they are also the ones causing performance problems and that is the reason we put them in their own Prometheus so they don't affect the team's rules.
+

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -301,6 +301,8 @@ resource "aws_iam_role_policy" "grafana_datasource" {
 #########################################################
 
 resource "null_resource" "infrastructure" {
+  count = var.split_prometheus ? 1 : 0
+
   depends_on = [helm_release.prometheus_operator]
 
   provisioner "local-exec" {

--- a/resources/prometheus-infrastructure.yaml
+++ b/resources/prometheus-infrastructure.yaml
@@ -1,0 +1,74 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: prometheus-cloud-platform
+  namespace: monitoring
+spec:
+  ports:
+  - name: web
+    port: 9090
+    protocol: TCP
+    targetPort: 9090
+  selector:
+    app: prometheus
+    prometheus: prometheus-cloud-platform
+  sessionAffinity: None
+  type: ClusterIP
+---
+apiVersion: monitoring.coreos.com/v1
+kind: Prometheus
+metadata:
+  labels:
+    app: prometheus-cloud-platform
+  name: prometheus-cloud-platform
+  namespace: monitoring
+spec:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: beta.kubernetes.io/instance-type
+            operator: In
+            values:
+            - r5.2xlarge
+  alerting:
+    alertmanagers:
+    - apiVersion: v2
+      name: prometheus-operator-alertmanager
+      namespace: monitoring
+      pathPrefix: /
+      port: web
+  baseImage: quay.io/prometheus/prometheus
+  enableAdminAPI: false
+  externalLabels:
+    clusterName: live-1
+  listenLocal: false
+  logFormat: logfmt
+  logLevel: info
+  paused: false
+  podMonitorNamespaceSelector: {}
+  podMonitorSelector: {}
+  portName: web
+  replicas: 1
+  retention: 1d
+  routePrefix: /
+  ruleNamespaceSelector: {}
+  ruleSelector:
+    matchLabels:
+      release: prometheus-operator
+  securityContext:
+    fsGroup: 2000
+    runAsNonRoot: true
+    runAsUser: 1000
+  serviceAccountName: prometheus-operator-prometheus
+  serviceMonitorNamespaceSelector: {}
+  serviceMonitorSelector:
+    matchLabels:
+      release: prometheus-operator
+  tolerations:
+  - effect: NoSchedule
+    key: monitoring-node
+    operator: Equal
+    value: "true"
+  version: v2.17.2

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -238,21 +238,7 @@ grafana:
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:
-%{ if eks ~}
   enabled: true
-%{ else ~}
-  enabled: false
-%{ endif ~}
-
-## Component scraping kubeDns. Use either this or coreDns
-##
-kubeDns:
-%{ if eks ~}
-  enabled: false
-%{ else ~}
-  enabled: true
-%{ endif ~}
-
 
 ## Component scraping etcd
 ##
@@ -386,7 +372,15 @@ prometheus:
     ## If unspecified the release `app` and `release` will be used as the label selector
     ## to load rules
     ##
+    
+    # More information about this in the README.md
+    %{ if split_prometheus ~}
+    ruleSelector:
+      matchLabels:
+        prometheus: cloud-platform
+    %{ else ~}
     ruleSelector: {}
+    %{ endif ~}
 
     ## Namespaces to be selected for PrometheusRules discovery.
     ## If nil, select own namespace. Namespaces to be selected for ServiceMonitor discovery.

--- a/variables.tf
+++ b/variables.tf
@@ -62,6 +62,12 @@ variable "oidc_issuer_url" {
   description = "Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy)"
 }
 
+variable "split_prometheus" {
+  description = "Create a second Prometheus which will match (for rules) only rules with release=prometheus-operator labels and make the main prometheus only look for prometheus=cloud-platform (more info in the README)"
+  type        = bool
+  default     = false
+}
+
 # EKS variables
 variable "eks" {
   description = "Where are you applying this modules in kOps cluster or in EKS (KIAM or KUBE2IAM?)"


### PR DESCRIPTION
- add(prometheus): New Prometheus in place to manage the infrastructure rules.
- add(oidcProxy): In order to access to the new Prometheus we need to enable another OIDC Proxy
- remove(kubeDNSchecks): We are not using CoreDNS across EKS and KOPS