### PR TITLE
Fixed indentation

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -374,13 +374,13 @@ prometheus:
     ##
     
     # More information about this in the README.md
-    %{ if split_prometheus ~}
+%{ if split_prometheus ~}
     ruleSelector:
       matchLabels:
         prometheus: cloud-platform
-    %{ else ~}
+%{ else ~}
     ruleSelector: {}
-    %{ endif ~}
+%{ endif ~}
 
     ## Namespaces to be selected for PrometheusRules discovery.
     ## If nil, select own namespace. Namespaces to be selected for ServiceMonitor discovery.


### PR DESCRIPTION
Otherwise, we see:

```
Error: ---> error converting YAML to JSON: yaml: line 911: did not find expected key # Default values for prometheus-operator.                                                                                                                                                                        



    # More information about this in the README.md                                                                                                                                                                                                                                                    
        ruleSelector:                                                                                                                                                                                                                                                                                 
      matchLabels:                                                                                                                                                                                                                                                                                    
        prometheus: cloud-platform                                                                                                                                                                                                                                                                    

```