### PR TITLE
Moved network policies from environment repo to the terraform module

### DIFF
--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -53,7 +53,7 @@ data "aws_iam_policy_document" "ecr_exporter_assume" {
 
 resource "aws_iam_role" "ecr_exporter" {
   count = var.enable_ecr_exporter && var.eks == false ? 1 : 0
-  
+
   name               = "ecr-exporter.${var.cluster_domain_name}"
   assume_role_policy = data.aws_iam_policy_document.ecr_exporter_assume.json
 }


### PR DESCRIPTION
As part of https://github.com/ministryofjustice/cloud-platform/issues/2369 we are setting up the network policies within the terraform module, so test clusters can also have them.
