### PR TITLE
Increased timeout for cloudwatch exporter

### DIFF
--- a/templates/cloudwatch-exporter.yaml
+++ b/templates/cloudwatch-exporter.yaml
@@ -266,4 +266,4 @@ serviceMonitor:
   labels:
     app: prometheus-cloudwatch-exporter
   # Set timeout for scrape
-  timeout: 90s
+  timeout: 180s


### PR DESCRIPTION
Sometimes the service is timing out before actually getting the results, you can see the gaps in Prometheus.