### PR TITLE
Added custom labels (release: prometheus-operator) for Prometheus rules

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     prometheus: prometheus-operator
     role: alert-rules
+    release: prometheus-operator
   name: prometheus-operator-custom-kubernetes-apps.rules
 spec:
   groups:

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -4,6 +4,7 @@ metadata:
   labels:
     prometheus: prometheus-operator
     role: alert-rules
+    release: prometheus-operator
   name: prometheus-operator-custom-alerts-node.rules
 spec:
   groups:


### PR DESCRIPTION
Some of our custom rules were not picked up because of labelling issues. This PR adds the required labels to Prometheus. 