### PR TITLE
Change all custom alarm expressions based on new annotation

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -69,7 +69,7 @@ spec:
         100 * kube_resourcequota{job="kube-state-metrics", type="used"} 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         / ignoring(instance, job, type)
         (kube_resourcequota{job="kube-state-metrics", type="hard"} > 0)
         > 90
@@ -85,7 +85,7 @@ spec:
         rate(kube_pod_container_status_restarts_total{job="kube-state-metrics"}[15m]) 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         * 60 * 5 > 0
       for: 1h
       labels:
@@ -99,7 +99,7 @@ spec:
         sum by (namespace, pod) (kube_pod_status_phase{job="kube-state-metrics", phase=~"Pending|Unknown"}) 
         * on (namespace) 
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 0
       for: 1h
       labels:
@@ -114,7 +114,7 @@ spec:
         kube_deployment_status_observed_generation{job="kube-state-metrics"}
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         !=
         kube_deployment_metadata_generation{job="kube-state-metrics"}
       for: 15m
@@ -129,7 +129,7 @@ spec:
         kube_deployment_spec_replicas{job="kube-state-metrics"} 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         != kube_deployment_status_replicas_available{job="kube-state-metrics"}
       for: 1h
       labels:
@@ -143,7 +143,7 @@ spec:
         kube_statefulset_status_replicas_ready{job="kube-state-metrics"}
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         !=
         kube_statefulset_status_replicas{job="kube-state-metrics"}
       for: 15m
@@ -159,7 +159,7 @@ spec:
         kube_statefulset_status_observed_generation{job="kube-state-metrics"}        
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         !=
         kube_statefulset_metadata_generation{job="kube-state-metrics"}
       for: 15m
@@ -175,7 +175,7 @@ spec:
           kube_statefulset_status_current_revision{job="kube-state-metrics"}
           * on (namespace)
           group_left() 
-          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
             unless
           kube_statefulset_status_update_revision{job="kube-state-metrics"}
         )
@@ -184,7 +184,7 @@ spec:
           kube_statefulset_replicas{job="kube-state-metrics"}
           * on (namespace)
           group_left() 
-          kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+          kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
           !=
           kube_statefulset_status_replicas_updated{job="kube-state-metrics"}
         )  
@@ -200,7 +200,7 @@ spec:
         kube_daemonset_status_number_ready{job="kube-state-metrics"}
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         /
         kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"} * 100 < 100
       for: 15m
@@ -215,7 +215,7 @@ spec:
         kube_daemonset_status_desired_number_scheduled{job="kube-state-metrics"}     
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"}
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"}
         -
         kube_daemonset_status_current_number_scheduled{job="kube-state-metrics"} > 0 
       for: 10m
@@ -230,7 +230,7 @@ spec:
         kube_daemonset_status_number_misscheduled{job="kube-state-metrics"} 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 0
       for: 10m
       labels:
@@ -244,7 +244,7 @@ spec:
         time() - kube_cronjob_next_schedule_time{job="kube-state-metrics"} 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 3600
       for: 1h
       labels:
@@ -258,7 +258,7 @@ spec:
         kube_job_spec_completions{job="kube-state-metrics"} - kube_job_status_succeeded{job="kube-state-metrics"} 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 0
       for: 1h
       labels:
@@ -271,7 +271,7 @@ spec:
         kube_job_status_failed{job="kube-state-metrics"}  
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 0
       for: 1h
       labels:
@@ -283,7 +283,7 @@ spec:
         100 * (count(up == 0) BY (job) / count(up) BY (job)) 
         * on (namespace)
         group_left() 
-        kube_namespace_annotations{annotation_cloud_platform_justice_gov_uk_business_unit="cloud-platform"} 
+        kube_namespace_annotations{annotation_cloud_platform_out_of_hours_alert="true"} 
         > 10
       for: 10m
       labels:


### PR DESCRIPTION
Change all custom alarms to use the new NS annotation of `cloud_platform_out_of_hours_alert="true"`