### PR TITLE
removal of LoadBalancer5XXCountHigh alert - addition of latency and http request error alerts

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -593,3 +593,38 @@ Check the API logs to identify and get more information:
 ```
  stern --namespace kube-system kube-apiserver-ip
 ```
+
+## HTTP-Error-5xx---warning
+```
+HTTP-Error-5xx---warning
+Severity: warning
+```
+This alert is triggered when a http error requests for nginx_ingress_controller (5xx) exceed 1% of all requests for 5 minutes
+
+Expression:
+```
+expr: sum by(pod)(rate(nginx_ingress_controller_requests{status=~"2.*",ingress=~".*"pod=~".*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_requests{ingress=~".*"pod=~".*"}[5m])) * 100 > 1 for 5 minutes
+```
+### Action
+
+Investigation in Kibana required.
+The following Prometheus expression summary of all request nginx_ingress_controller_requests may also help with investigation:
+
+```
+sum(label_replace(rate(nginx_ingress_controller_requests{namespace="ingress-controllers",ingress=~".*"}[2m]), "status_code", "${1}xx", "status", "(.)..")) by (status_code)
+```
+
+## NginxIngress-Latency(ms)---warning
+```
+NginxIngress-Latency(ms)---warning
+Severity: warning
+```
+This alert is triggered when latency exceeds 300 milliseconds for 5 minutes for nginx_ingress_controller_requests.
+
+Expression:
+```
+expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~".*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~".*"}[5m])) * 1000 > 300 for 5 minutes
+```
+### Action
+
+Investigation in Kibana required

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -140,15 +140,56 @@ spec:
       annotations:
         message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is critically high'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#root-volume-utilisation---critical
-    - alert: LoadBalancer5XXCountHigh
-      expr: |-
-        count by (service) (increase(http_requests_total{code=~"5.*"}[15m]))  >=  10
-      for: 15m
+    - alert: NginxIngress-5xx-modsec-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_requests{status=~"5.*",ingress=~".*",pod=~"modsec01.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_requests{ingress=~".*",pod=~"modsec01.*"}[5m])) * 100  > 1
+      for: 5m
       labels:
         severity: warning
       annotations:
-        message: HTTPCode_Target_5XX_Count high for `{{$labels.service}}. HTTPCode_Target_5XX_Count high'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+        message: '{{ $labels.pod}} - modsec01 ingress -has been receiving a high percentage of HTTP Error 5xx requests for 5 minutes, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#HTTP-Error-5xx---warning
+    - alert: NginxIngress-5xx-nginx-ingress-acme-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_requests{status=~"5.*",ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_requests{ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) * 100 > 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - nginx-ingress-acme ingress -has been receiving a high percentage of HTTP Error 5xx requests for 5 minutes, with a value of {{ $value }}{{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#HTTP-Error-5xx---warning
+    - alert: NginxIngress-5xx-k8snginx--ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_requests{status=~"5.*",ingress=~".*",pod=~"k8snginx.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_requests{ingress=~".*",pod=~"k8snginx.*"}[5m])) * 100 > 1
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - k8snginx ingress -has been receiving a high percentage of HTTP Error 5xx requests for 5 minutes, with a value of {{ $value }}{{ $labels.namespace}} namespace. Please investigate' 
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#HTTP-Error-5xx---warning
+
+    - alert: NginxIngress-Latency(ms)-modsec-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"modsec01.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"modsec01.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - modsec01 ingress -latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+    - alert: NginxIngress-Latency(ms)-nginx-ingress-acme-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - nginx-ingress-acme ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+    - alert: NginxIngress-Latency(ms)-k8snginx-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"k8snginx.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"k8snginx.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - k8snginx ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+
     - alert: NginxConfigReloadFailureWarning
       annotations:
         message: The Nginx Config has failed to reload for pod {{ $labels.pod }}


### PR DESCRIPTION
Why:
[Check all custom Prometheus Rules #2475](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2475)
removal of LoadBalancer5XXCountHigh alert - addition of latency and http request error alerts for ingress-controller pods
The 1% of all requests for 5xx and the 300ms for latency are a bit arbitrary at the moment - however we can tweak as and when it becomes apparent problems are taking place (and they can act as an advance indicator). 