### PR TITLE
updateprometheus custom alerts  new alert for coreDNS

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -343,4 +343,23 @@ spec:
       for: 1m
       labels:
         severity: info-warning
-        
+    - alert: coreDNSLatencyWarning
+      annotations:
+        message: The coreDNS for the Kubernetes cluster has a 99th percentile latency of {{ $value }} seconds for
+          {{ $labels.verb }} {{ $labels.resource }}. The high latency of the request could mean a degradation in the Kubernetes cluster service. This check is comparing the percentile against the average using the operator histogram
+        runbook_url: https://sysdig.com/blog/how-to-monitor-coredns/
+      expr: |-
+        histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{job="coredns"}[5m])) by(server, zone, le)) > 1
+      for: 10m
+      labels:
+        severity: warning        
+    - alert: coreDNSLatencyCritical
+      annotations:
+        message: The coreDNS for the Kubernetes cluster has a 99th percentile latency of {{ $value }} seconds for
+          {{ $labels.verb }} {{ $labels.resource }}. The high latency of the request could mean a degradation in the Kubernetes cluster service. This check is comparing the percentile against the average using the operator histogram
+        runbook_url: https://sysdig.com/blog/how-to-monitor-coredns/
+      expr: |-
+        histogram_quantile(0.99, sum(rate(coredns_dns_request_duration_seconds_bucket{job="coredns"}[5m])) by(server, zone, le)) > 4
+      for: 10m
+      labels:
+        severity: critical


### PR DESCRIPTION
Why:
[Check all custom Prometheus Rules #2475](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/2475)
Please see https://mojdt.slack.com/archives/C514ETYJX/p1604495631237800
https://sysdig.com/blog/how-to-monitor-coredns/