### PR TITLE
Update prometheus-operator.yaml.tpl

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -335,7 +335,7 @@ prometheusOperator:
 
   ## Attempt to clean up CRDs created by Prometheus Operator.
   ##
-  cleanupCustomResource: true
+  cleanupCustomResource: false
 
 ## Deploy a Prometheus instance
 ##


### PR DESCRIPTION
We don't need to destroy the CRDs when Prometheus Operator is uninstalled