### PR TITLE
Update prometheus.tf to avoid interpolation warning

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -94,8 +94,8 @@ resource "helm_release" "prometheus_operator" {
     grafana_ingress                            = local.grafana_ingress
     grafana_root                               = local.grafana_root
     pagerduty_config                           = var.pagerduty_config
-    alertmanager_routes                        = "${join("", data.template_file.alertmanager_routes.*.rendered)}"
-    alertmanager_receivers                     = "${join("", data.template_file.alertmanager_receivers.*.rendered)}"
+    alertmanager_routes                        = join("", data.template_file.alertmanager_routes.*.rendered)
+    alertmanager_receivers                     = join("", data.template_file.alertmanager_receivers.*.rendered)
     prometheus_ingress                         = local.prometheus_ingress
     random_username                            = random_id.username.hex
     random_password                            = random_id.password.hex


### PR DESCRIPTION
We are getting:

```
Warning: Interpolation-only expressions are deprecated

  on .terraform/modules/prometheus/prometheus.tf line 97, in resource "helm_release" "prometheus_operator":
  97:     alertmanager_routes                        = "${join("", data.template_file.alertmanager_routes.*.rendered)}" 
```

This PR fixes it.