### PR TITLE
alertmanager storage typo

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -154,7 +154,7 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
-          storageClassName: ${storage_class}
+          storageClassName: gp2-expand
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -152,14 +152,13 @@ alertmanager:
     ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/user-guides/storage.md
     ##
     storage:
-    volumeClaimTemplate:
-      spec:
-        storageClassName: ${storage_class}
-        accessModes: ["ReadWriteOnce"]
-        resources:
-          requests:
-            storage: 1Gi
-      selector: {}
+      volumeClaimTemplate:
+        spec:
+          storageClassName: ${storage_class}
+          accessModes: ["ReadWriteOnce"]
+          resources:
+            requests:
+              storage: 1Gi
 
     ## 	The external URL the Alertmanager instances will be available under. This is necessary to generate correct URLs. This is necessary if Alertmanager is not served from root of a DNS name.	string	false
     ##


### PR DESCRIPTION
to check (see cluster raz-test):
```
# kubectl get pvc -A
NAMESPACE    NAME                                                                                                             STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
monitoring   alertmanager-prometheus-operator-kube-p-alertmanager-db-alertmanager-prometheus-operator-kube-p-alertmanager-0   Bound    pvc-03889d6a-3cb4-483a-9bd1-2d055863033d   1Gi        RWO            gp2-expand     67s
```
silence any alarm
```
bash-5.0# kubectl -n monitoring delete pod alertmanager-prometheus-operator-kube-p-alertmanager-0
```
when the pod comes back, the silenced alarm must still be present