### PR TITLE
Set NodeFilesystemSpaceFillingUp alert to NULL

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -38,6 +38,9 @@ alertmanager:
       receiver: 'null'
       routes:
       - match:
+          alertname: NodeFilesystemSpaceFillingUp
+        receiver: 'null'
+      - match:
           alertname: KubeQuotaExceeded
         receiver: 'null'
       - match:


### PR DESCRIPTION
NodeFilesystemSpaceFillingUp has been alerting a lot on low-priority-alarms and it requires a prune of docker images or gets resolved by itself.

The cause of this alert is normally when we create a new node and lots of pods are being created. This alert is a prediect_linear which notifies us that at this rate disk space will be used up in the next 4 hours. So far it has not used up all the space. This is due to a garbage collection action runs on the nodes at 80%+ usage. 

There is also alarms for when/if disk space is below 5%