### PR TITLE
cpu-high and critical change irate to rate

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -110,7 +110,7 @@ This alert is triggered when the CPU for a node is running at or over 80% for 5 
 
 Expression:
 ```
-expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
 for: 5m
 ```
 ### Action

--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -110,7 +110,7 @@ This alert is triggered when the CPU for a node is running at or over 80% for 5 
 
 Expression:
 ```
-expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
+expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 80
 for: 5m
 ```
 ### Action
@@ -118,6 +118,15 @@ for: 5m
 Run the following to get a breakdown of CPU usage:
 ```bash
 kubectl describe node <node_name>
+```
+
+and the following to display resource (CPU/Memory/Storage) usage:
+```bash
+kubectl top node -n <namespace>
+```
+
+```bash
+kubectl top pod -n <namespace>
 ```
 
 Please read the Kubernetes documentation of the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu)
@@ -129,11 +138,11 @@ Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/adminis
 Also consider running the following searches for the relevant ip address in Kibana (around the time of the alert):
 
 ```
-_HOSTNAME: "ip-172-20" AND MESSAGE:"Error"
+kubernetes.host: "ip-172-20" AND "error"
 ```
 
 ```
-_HOSTNAME: "ip-172-20" AND MESSAGE:"Error syncing"
+kubernetes.host: "ip-172-20" AND "error syncing"
 ```
 
 Look for pods where containers are failing to start. Contact the relevant project owners as necessary.
@@ -147,7 +156,7 @@ This alert is triggered when the CPU for a node is running at or over 95% for 5 
 
 Expression:
 ```
-expr: 100 - (avg by(instance) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
 for: 5m
 ```
 ### Action
@@ -155,6 +164,15 @@ for: 5m
 Run the following to get a breakdown of CPU usage:
 ```bash
 kubectl describe node <node_name>
+```
+
+and the following to display resource (CPU/Memory/Storage) usage:
+```bash
+kubectl top node -n <namespace>
+```
+
+```bash
+kubectl top pod -n <namespace>
 ```
 
 Please read the Kubernetes documentation of the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu)
@@ -166,11 +184,11 @@ Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/adminis
 Also consider running the following searches for the relevant ip address in Kibana (around the time of the alert):
 
 ```
-_HOSTNAME: "ip-172-20" AND MESSAGE:"Error"
+kubernetes.host: "ip-172-20" AND "error"
 ```
 
 ```
-_HOSTNAME: "ip-172-20" AND MESSAGE:"Error syncing"
+kubernetes.host: "ip-172-20" AND "error syncing"
 ```
 
 Look for pods where containers are failing to start. Contact the relevant project owners as necessary.

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -19,7 +19,7 @@ spec:
         message: 'A node is reporting low disk space below 10%. Action is required on a node.'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#node-disk-space-low
     - alert: CPU-High
-      expr: 100 - (avg by (instance,pod) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 85
+      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
       for: 5m
       labels:
         severity: warning
@@ -27,7 +27,7 @@ spec:
         message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}. Instance {{ $labels.instance }} CPU usage is dangerously high
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#cpu-high
     - alert: CPU-Critical
-      expr: 100 - (avg by (instance,pod) (irate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
Why:
"irate should only be used when graphing volatile, fast-moving counters. <b>Use rate for alerts and slow-moving counters</b>, as brief changes in the rate can reset the FOR clause and graphs consisting entirely of rare spikes are hard to read."
See [irate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#irate)
and [rate()](https://prometheus.io/docs/prometheus/latest/querying/functions/#rate)