### PR TITLE
cpu - less noisy alerts

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -106,11 +106,11 @@ Limits can also be set on a [Namespace](https://kubernetes.io/docs/tasks/adminis
 CPU-High
 Severity: warning
 ```
-This alert is triggered when the CPU for a node is running at or over 80% for 5 minutes
+This alert is triggered when the CPU for a node is running at or over 95% for 10 minutes
 
 Expression:
 ```
-expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
+expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[10m])) * 100) > 95
 for: 5m
 ```
 ### Action
@@ -152,11 +152,11 @@ Look for pods where containers are failing to start. Contact the relevant projec
 CPU-Critical
 Severity: critical
 ```
-This alert is triggered when the CPU for a node is running at or over 95% for 5 minutes
+This alert is triggered when the CPU for a node is running at or over 99% for 10 minutes
 
 Expression:
 ```
-expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+expr: 100 - (avg by(instance) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 99
 for: 5m
 ```
 ### Action

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -19,7 +19,7 @@ spec:
         message: 'A node is reporting low disk space below 10%. Action is required on a node.'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#node-disk-space-low
     - alert: CPU-High
-      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 90
+      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[10m])) * 100) > 95
       for: 5m
       labels:
         severity: warning
@@ -27,7 +27,7 @@ spec:
         message: This device's CPU usage has exceeded the threshold with a value of {{ $value }}. Instance {{ $labels.instance }} CPU usage is dangerously high
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#cpu-high
     - alert: CPU-Critical
-      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[5m])) * 100) > 95
+      expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[10m])) * 100) > 99
       for: 5m
       labels:
         severity: critical


### PR DESCRIPTION
Trying to get the trade off between noisy cpu alerts and actually notifying cloud-platforms of a real problem right