### PR TITLE
Change disk-space alert to ignore snap mountpoints

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -31,11 +31,11 @@ Please read the documentation from [Kubernetes](https://github.com/kubernetes/ko
 Node-Disk-Space-Low
 Severity: warning
 ```
-This alert is triggered when a node has less than 10% disk space for 30 minutes. 
+This alert is triggered when a node has less than 10% disk space (Ignoring /snap/* mountpoints) for 30 minutes. 
 
 Expression:
 ```
-expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
+expr: ((node_filesystem_avail_bytes {mountpoint !~"/snap/.+"} * 100) / node_filesystem_size_bytes) < 10
 for: 30m
 ```
 ### Action

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -11,12 +11,12 @@ spec:
   - name: node.rules
     rules:
     - alert: Node-Disk-Space-Low
-      expr: ((node_filesystem_avail_bytes * 100) / node_filesystem_size_bytes) < 10
+      expr: ((node_filesystem_avail_bytes {mountpoint !~"/snap/.+"} * 100) / node_filesystem_size_bytes) < 10
       for: 30m
       labels:
         severity: warning
       annotations:
-        message: 'A node is reporting low disk space below 10%. Action is required on a node.'
+        message: 'A node is reporting low disk space below 10% (Ignoring /snap/* mountpoints). Action is required on a node.'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#node-disk-space-low
     - alert: CPU-High
       expr: 100 - (avg by (instance,pod) (rate(node_cpu_seconds_total{mode="idle"}[10m])) * 100) > 95


### PR DESCRIPTION
WHAT
Change disk-space alert to ignore snap mountpoints

WHY
For the kops 1.18 upgrade, the image for the nodes changes from debian to Ubuntu. 
Ubuntu images create /snap/* mountpoints used for Ubuntu snap packages. We do not use these and they are almost always 100% full even with garbage collection running. 
This alert will ignore all /snap* mountpoints but alert on all others. There is a separate specific alert for /root.