### PR TITLE
Setting IRSA for ECR with default service account

### DIFF
--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -84,7 +84,7 @@ module "iam_assumable_role_ecr_exporter" {
   role_name                     = "ecr-exporter.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
   role_policy_arns              = [var.enable_ecr_exporter && var.eks ? aws_iam_policy.ecr_exporter.0.arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:test-prometheus-ecr-exporter"]
+  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:default"]
 }
 
 resource "aws_iam_policy" "ecr_exporter" {


### PR DESCRIPTION
Unfortunately, ECR is using the default serviceAccount to run the pod instead of its own. This PR links the AWS role to the default SA