### PR TITLE
Implement URLs for monitoring stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ module "monitoring" {
 | [aws_iam_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) |
 | [aws_iam_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) |
 | [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
+| [kubernetes_ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress) |
 | [kubernetes_limit_range](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/limit_range) |
 | [kubernetes_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) |
 | [kubernetes_network_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) |
@@ -86,7 +87,9 @@ module "monitoring" {
 | enable\_thanos\_compact | Enable or not Thanos Compact - not semantically concurrency safe and must be deployed as a singleton against a bucket | `bool` | `false` | no |
 | enable\_thanos\_helm\_chart | Enable or not Thanos Helm Chart - (do NOT confuse this with thanos sidecar within prometheus-operator) | `bool` | `false` | no |
 | enable\_thanos\_sidecar | Enable or not Thanos sidecar. Basically defines if we want to send cluster metrics to thanos's S3 bucket | `bool` | `false` | no |
+| grafana\_ingress\_redirect\_url | grafana url to use live\_domain, 'cloud-platform.service.justice.gov.uk' | `string` | `""` | no |
 | iam\_role\_nodes | Nodes IAM role ARN in order to create the KIAM/Kube2IAM | `string` | n/a | yes |
+| ingress\_redirect | Enable ingress\_redirect, to use live\_domain, 'cloud-platform.service.justice.gov.uk' | `bool` | `false` | no |
 | oidc\_components\_client\_id | OIDC ClientID used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | oidc\_components\_client\_secret | OIDC ClientSecret used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | oidc\_issuer\_url | Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |

--- a/locals.tf
+++ b/locals.tf
@@ -2,25 +2,26 @@
 locals {
   live_workspace = "live-1"
   live_domain    = "cloud-platform.service.justice.gov.uk"
+  ingress_redirect = terraform.workspace == local.live_workspace ? true : false
 
-  alertmanager_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://alertmanager", local.live_domain) : format(
+  alertmanager_ingress = format(
     "%s.%s",
-    "https://alertmanager.apps",
+    "https://alertmanager",
     var.cluster_domain_name,
   )
-  grafana_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "grafana", local.live_domain) : format(
+  grafana_ingress = format(
     "%s.%s",
-    "grafana.apps",
+    "grafana",
     var.cluster_domain_name,
   )
-  grafana_root = terraform.workspace == local.live_workspace ? format("%s.%s", "https://grafana", local.live_domain) : format(
+  grafana_root = format(
     "%s.%s",
-    "https://grafana.apps",
+    "https://grafana",
     var.cluster_domain_name,
   )
-  prometheus_ingress = terraform.workspace == local.live_workspace ? format("%s.%s", "https://prometheus", local.live_domain) : format(
+  prometheus_ingress = format(
     "%s.%s",
-    "https://prometheus.apps",
+    "https://prometheus",
     var.cluster_domain_name,
   )
 }

--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -33,12 +33,25 @@ extraArgs:
 
 ingress:
   enabled: true
+  annotations: {
+    external-dns.alpha.kubernetes.io/aws-weight: "100",
+    external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}"
+  }
   path: /
+%{ if ingress_redirect ~}
+  hosts:
+    - "${hostname}"
+    - "${live_domain_hostname}"
+  tls:
+    - hosts:
+      - "${hostname}"
+      - "${live_domain_hostname}"
+%{ else ~}
   hosts:
     - "${hostname}"
   tls:
     - hosts:
       - "${hostname}"
-
+%{ endif ~}
 serviceAccount:
   enabled: false

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -199,6 +199,10 @@ grafana:
 
   ingress:
     enabled: true
+    annotations: {
+      external-dns.alpha.kubernetes.io/aws-weight: "100",
+      external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}"
+    }
     hosts:
     - "${ grafana_ingress }"
     tls:

--- a/variables.tf
+++ b/variables.tf
@@ -83,6 +83,11 @@ variable "eks" {
   default     = false
 }
 
+variable "ingress_redirect" {
+  description = "Enable ingress_redirect, to use live_domain, 'cloud-platform.service.justice.gov.uk'"
+  type        = bool
+  default     = false
+}
 variable "eks_cluster_oidc_issuer_url" {
   description = "If EKS variable is set to true this is going to be used when we create the IAM OIDC role"
   type        = string
@@ -103,6 +108,13 @@ variable "enable_large_nodesgroup" {
 
 variable "dockerhub_password" {
   description = "DockerHub password - required to avoid hitting Dockerhub API limits in EKS clusters"
+  default     = ""
+  type        = string
+}
+
+
+variable "grafana_ingress_redirect_url" {
+  description = "grafana url to use live_domain, 'cloud-platform.service.justice.gov.uk'"
   default     = ""
   type        = string
 }


### PR DESCRIPTION
This is in light of the EKS migration
 -  Add external-dns annotation to grafana/kibana/prometheus/alertmanager
 - Configure cluster-specific and live_domain hosts in ingress, for Prometheus and alert manager
 - Create ingress to redirect_grafana while accessing live_domain,
    cannot be set up as we did for Prometheus and alert manager as GF_SERVER_ROOT_URL supports only one URL.
    
This is related to:
https://github.com/ministryofjustice/cloud-platform/issues/3007