### PR TITLE
Setting static storage class to io1-expand everywhere (EKS and KOPS)

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -104,7 +104,6 @@ resource "helm_release" "prometheus_operator" {
     monitoring_aws_role                        = var.eks ? module.iam_assumable_role_monitoring.this_iam_role_name : aws_iam_role.monitoring.0.name
     clusterName                                = terraform.workspace
     enable_prometheus_affinity_and_tolerations = var.enable_prometheus_affinity_and_tolerations
-    storage_class                              = var.eks ? "gp2-expand" : "io1-expand"
     enable_thanos_sidecar                      = var.enable_thanos_sidecar
     enable_large_nodesgroup                    = var.enable_large_nodesgroup
 

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -478,7 +478,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: ${storage_class}
+          storageClassName: io1-expand
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:


### PR DESCRIPTION
`io1-expand` is in EKS already, we can set the prometheus one in either side (EKS/kops) to use it.
