### PR TITLE
Increase prometheus container memory to 60000Mi

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -380,7 +380,7 @@ prometheus:
     ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
     ##
     tolerations:
-      - key: "cloud-platform.justice.gov.uk/monitoring-ng"
+      - key: "monitoring-node"
         operator: "Equal"
         value: "true"
         effect: "NoSchedule"
@@ -403,7 +403,7 @@ prometheus:
         memory: "14000Mi"
         cpu: "1300m"
       limits:
-        memory: "25000Mi"
+        memory: "60000Mi"
         cpu: "3000m"
     %{ endif }
 


### PR DESCRIPTION
The usage of the prometheus container has risen in range of 34000Mi and without increasing this limit, the pod would terminate with OOMKilled