### PR TITLE
Update ingresses to ignore aws-weight annotation

### DIFF
--- a/prometheus.tf
+++ b/prometheus.tf
@@ -374,7 +374,7 @@ resource "kubernetes_ingress" "ingress_redirect_grafana" {
     annotations = {
       "external-dns.alpha.kubernetes.io/aws-weight" = "100"
       "external-dns.alpha.kubernetes.io/set-identifier" = "dns-grafana"
-      "cloud-platform.justice.gov.uk/ignore-external-dns-weight" : true
+      "cloud-platform.justice.gov.uk/ignore-external-dns-weight" : "true"
       "kubernetes.io/ingress.class" = "nginx"
       "nginx.ingress.kubernetes.io/permanent-redirect" = local.grafana_root
     }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -374,6 +374,7 @@ resource "kubernetes_ingress" "ingress_redirect_grafana" {
     annotations = {
       "external-dns.alpha.kubernetes.io/aws-weight" = "100"
       "external-dns.alpha.kubernetes.io/set-identifier" = "dns-grafana"
+      "cloud-platform.justice.gov.uk/ignore-external-dns-weight" : true
       "kubernetes.io/ingress.class" = "nginx"
       "nginx.ingress.kubernetes.io/permanent-redirect" = local.grafana_root
     }

--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -36,7 +36,7 @@ ingress:
   annotations: {
     external-dns.alpha.kubernetes.io/aws-weight: "100",
     external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}",
-    cloud-platform.justice.gov.uk/ignore-external-dns-weight: true
+    cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
   }
   path: /
 %{ if ingress_redirect ~}

--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -35,7 +35,8 @@ ingress:
   enabled: true
   annotations: {
     external-dns.alpha.kubernetes.io/aws-weight: "100",
-    external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}"
+    external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}",
+    cloud-platform.justice.gov.uk/ignore-external-dns-weight: true
   }
   path: /
 %{ if ingress_redirect ~}

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -202,7 +202,7 @@ grafana:
     annotations: {
       external-dns.alpha.kubernetes.io/aws-weight: "100",
       external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}",
-      cloud-platform.justice.gov.uk/ignore-external-dns-weight: true
+      cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
     }
     hosts:
     - "${ grafana_ingress }"

--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -201,7 +201,8 @@ grafana:
     enabled: true
     annotations: {
       external-dns.alpha.kubernetes.io/aws-weight: "100",
-      external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}"
+      external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}",
+      cloud-platform.justice.gov.uk/ignore-external-dns-weight: true
     }
     hosts:
     - "${ grafana_ingress }"


### PR DESCRIPTION
Update ingresses with annotation `cloud-platform.justice.gov.uk/ignore-external-dns-weight:. These ingress are specific to cluster and will not have any weighted policy and hence ignore the check for aws-weight and set-identifier annotation