### PR TITLE
Increase PV size to 750Gi for io1 storage

### DIFF
--- a/templates/prometheus-operator.yaml.tpl
+++ b/templates/prometheus-operator.yaml.tpl
@@ -487,7 +487,7 @@ prometheus:
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
-              storage: 75Gi
+              storage: 750Gi
 
 %{ if enable_thanos_sidecar == true ~}
     thanos: 


### PR DESCRIPTION
For io1 storage, the io1 to volume ratio should be 50:1. Prometheus pod pending to create with error `Failed to provision volume with StorageClass "io1-expand": InvalidParameterValue: Iops to volume size ratio of 266.666667 is too high; maximum is 50` and this PR fixes it.
