### PR TITLE
upgrade CW exporter

### DIFF
--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -8,7 +8,7 @@ resource "helm_release" "cloudwatch_exporter" {
   name       = "cloudwatch-exporter"
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://prometheus-community.github.io/helm-charts"
-  version    = "0.17.2"
+  version    = "0.18.0"
   chart      = "prometheus-cloudwatch-exporter"
 
   values = [templatefile("${path.module}/templates/cloudwatch-exporter.yaml", {


### PR DESCRIPTION
This goes from 0.10 to 0.12, should have no change for metrics, just dependencies updates: https://github.com/prometheus/cloudwatch_exporter/releases
