### PR TITLE
bitnami-helm-chart-for-metrics-server-3411

### DIFF
--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -1,5 +1,5 @@
 
-resource "helm_release" "metrics-server" {
+resource "helm_release" "metrics_server" {
   name       = "metrics-server"
   chart      = "metrics-server"
   repository = "https://charts.bitnami.com/bitnami"

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -2,26 +2,26 @@
 resource "helm_release" "metrics_server" {
   name       = "metrics-server"
   chart      = "metrics-server"
-  repository = "https://charts.helm.sh/stable"
+  repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "2.8.8"
+  version    = "5.10.14"
 
   lifecycle {
     ignore_changes = [keyring]
   }
 
   set {
-    name  = "args[0]"
+    name  = "extraArgs[0]"
     value = "--kubelet-insecure-tls"
   }
 
   set {
-    name  = "args[1]"
+    name  = "extraArgs[1]"
     value = "--kubelet-preferred-address-types=InternalIP"
   }
 
   set {
-    name  = "hostNetwork.enabled"
+    name  = "hostNetwork"
     value = "true"
   }
 

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -1,5 +1,5 @@
 
-resource "helm_release" "metrics_server" {
+resource "helm_release" "metrics-server" {
   name       = "metrics-server"
   chart      = "metrics-server"
   repository = "https://charts.bitnami.com/bitnami"

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -4,7 +4,7 @@ resource "helm_release" "metrics_server" {
   chart      = "metrics-server"
   repository = "https://charts.bitnami.com/bitnami"
   namespace  = "kube-system"
-  version    = "5.10.14"
+  version    = "5.11.0"
 
   lifecycle {
     ignore_changes = [keyring]

--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -11,13 +11,13 @@ resource "helm_release" "metrics_server" {
   }
 
   set {
-    name  = "extraArgs[0]"
-    value = "--kubelet-insecure-tls"
+    name  = "extraArgs.kubelet-insecure-tls"
+    value = "true"
   }
 
   set {
-    name  = "extraArgs[1]"
-    value = "--kubelet-preferred-address-types=InternalIP"
+    name  = "extraArgs.kubelet-preferred-address-types"
+    value = "InternalIP"
   }
 
   set {


### PR DESCRIPTION
Why:
[Use bitnami helm chart for metrics_server#3411](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3411).
With reference to [the old helm chart](https://github.com/helm/charts/tree/master/stable/metrics-server) and [the replacement bitnami chart](https://github.com/bitnami/charts/tree/master/bitnami/metrics-server)