### PR TITLE
Update values to create apiService

### DIFF
--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -24,5 +24,9 @@ resource "helm_release" "metrics_server" {
     name  = "hostNetwork"
     value = "true"
   }
+    set {
+    name  = "apiService.create"
+    value = "true"
+  }
 
 }


### PR DESCRIPTION
When moving from stable chart to bitnami, the default values for apiService has changed. This results in the metrics api not available after the move and hence, couldnot get any pod metrics from the cluster.

This will create the apiService of metrics server.