### PR TITLE
Implement URLs for monitoring stack

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,6 @@
 
 locals {
-  live_workspace   = "live-1"
+  live_workspace   = "live"
   live_domain      = "cloud-platform.service.justice.gov.uk"
   ingress_redirect = terraform.workspace == local.live_workspace ? true : false
 


### PR DESCRIPTION
This is in light of the EKS migration completed

These will be routed to the live cluster:
Prometheus: https://prometheus.cloud-platform.service.justice.gov.uk
AlertManager: https://alertmanager.cloud-platform.service.justice.gov.uk
Grafana: https://grafana.cloud-platform.service.justice.gov.uk

This is related to step4, after migration to eks completed to live
https://github.com/ministryofjustice/cloud-platform/issues/3007