### PR TITLE
update-pin-helm-version-in-modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,14 @@ module "monitoring" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6.0 |
 | <a name="provider_http"></a> [http](#provider\_http) | n/a |
 | <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | n/a |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |

--- a/versions.tf
+++ b/versions.tf
@@ -5,6 +5,7 @@ terraform {
     }
     helm = {
       source = "hashicorp/helm"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
Why: 
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)