### PR TITLE
update-prometheus-operator-and-crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ module "monitoring" {
 | <a name="input_oidc_components_client_secret"></a> [oidc\_components\_client\_secret](#input\_oidc\_components\_client\_secret) | OIDC ClientSecret used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | <a name="input_pagerduty_config"></a> [pagerduty\_config](#input\_pagerduty\_config) | Add PagerDuty key to allow integration with a PD service. | `any` | n/a | yes |
-| <a name="input_prometheus_operator_crd_version"></a> [prometheus\_operator\_crd\_version](#input\_prometheus\_operator\_crd\_version) | The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module | `string` | `"v0.53.1"` | no |
+| <a name="input_prometheus_operator_crd_version"></a> [prometheus\_operator\_crd\_version](#input\_prometheus\_operator\_crd\_version) | The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module | `string` | `"v0.60.1"` | no |
 
 ## Outputs
 

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -107,7 +107,7 @@ resource "helm_release" "prometheus_operator_eks" {
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
   namespace  = kubernetes_namespace.monitoring.id
-  version    = "30.0.1"
+  version    = "41.7.3"
   skip_crds  = true // Crds are managed seperately using resource kubectl_manifest.prometheus_operator_crds
 
   values = [templatefile("${path.module}/templates/prometheus-operator-eks.yaml.tpl", {

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -107,7 +107,7 @@ resource "helm_release" "prometheus_operator_eks" {
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
   namespace  = kubernetes_namespace.monitoring.id
-  version    = "41.7.3"
+  version    = "41.9.1"
   skip_crds  = true // Crds are managed seperately using resource kubectl_manifest.prometheus_operator_crds
 
   values = [templatefile("${path.module}/templates/prometheus-operator-eks.yaml.tpl", {

--- a/variables.tf
+++ b/variables.tf
@@ -119,7 +119,7 @@ variable "grafana_ingress_redirect_url" {
 }
 
 variable "prometheus_operator_crd_version" {
-  default     = "v0.53.1"
+  default     = "v0.60.1"
   description = "The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module"
 }
 


### PR DESCRIPTION
Why [Upgrade Prometheus-operator version to latest#4084](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/4084)
With reference to:[https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/41.7.3](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/41.7.3)
Note dependencies ok [Prerequisites](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/41.7.3#prerequisites_)
Note [39 to 40](https://artifacthub.io/packages/helm/prometheus-community/kube-prometheus-stack/41.7.3#from-39-x-to-40-x)
requires
```
kubectl delete daemonset -l app=prometheus-node-exporter
```
It is recreated when the terraform apply is carried out.