### PR TITLE
Upgrade grafana to latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,8 @@ module "monitoring" {
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iam_assumable_role_cloudwatch_exporter"></a> [iam\_assumable\_role\_cloudwatch\_exporter](#module\_iam\_assumable\_role\_cloudwatch\_exporter) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 3.13.0 |
+| <a name="module_iam_assumable_role_cloudwatch_exporter"></a> [iam\_assumable\_role\_cloudwatch\_exporter](#module\_iam\_assumable\_role\_cloudwatch\_exporter) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.24.1 |
 | <a name="module_iam_assumable_role_ecr_exporter"></a> [iam\_assumable\_role\_ecr\_exporter](#module\_iam\_assumable\_role\_ecr\_exporter) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 3.13.0 |
-| <a name="module_iam_assumable_role_grafana_datasource"></a> [iam\_assumable\_role\_grafana\_datasource](#module\_iam\_assumable\_role\_grafana\_datasource) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 3.13.0 |
 | <a name="module_iam_assumable_role_monitoring"></a> [iam\_assumable\_role\_monitoring](#module\_iam\_assumable\_role\_monitoring) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 3.13.0 |
 
 ## Resources
@@ -61,6 +60,8 @@ module "monitoring" {
 | [aws_iam_policy.ecr_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.grafana_datasource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_role.grafana_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.alertmanager_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.ecr_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -86,6 +87,8 @@ module "monitoring" {
 | [random_id.password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.session_secret](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
 | [random_id.username](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/id) | resource |
+| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
+| [aws_iam_policy_document.assume_role_with_oidc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.ecr_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.grafana_datasource_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |

--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -7,12 +7,12 @@ resource "helm_release" "cloudwatch_exporter" {
   name       = "cloudwatch-exporter"
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://prometheus-community.github.io/helm-charts"
-  version    = "0.18.0"
+  version    = "0.22.0"
   chart      = "prometheus-cloudwatch-exporter"
 
   values = [templatefile("${path.module}/templates/cloudwatch-exporter.yaml", {
-    iam_role            = module.iam_assumable_role_cloudwatch_exporter.this_iam_role_name
-    eks_service_account = module.iam_assumable_role_cloudwatch_exporter.this_iam_role_arn
+    iam_role            = module.iam_assumable_role_cloudwatch_exporter.iam_role_name
+    eks_service_account = module.iam_assumable_role_cloudwatch_exporter.iam_role_arn
   })]
 
   depends_on = [
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "cloudwatch_exporter" {
 
 module "iam_assumable_role_cloudwatch_exporter" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "3.13.0"
+  version                       = "4.24.1"
   create_role                   = var.enable_cloudwatch_exporter ? true : false
   role_name                     = "cloudwatch.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url

--- a/grafana-role.tf
+++ b/grafana-role.tf
@@ -1,0 +1,137 @@
+######################
+# Grafana Cloudwatch #
+######################
+
+# Grafana datasource for cloudwatch
+# Ref: https://github.com/grafana/helm-charts/blob/main/charts/grafana/values.yaml
+
+# Minimal policy permissions 
+# Ref: https://grafana.com/docs/grafana/latest/datasources/aws-cloudwatch/
+
+resource "aws_iam_policy" "grafana_datasource" {
+
+  name_prefix = "grafana"
+  description = "EKS grafana datasource policy for cluster ${var.cluster_domain_name}"
+  policy      = data.aws_iam_policy_document.grafana_datasource_irsa.json
+}
+
+data "aws_iam_policy_document" "grafana_datasource_irsa" {
+  statement {
+    actions = [
+      "logs:DescribeLogGroups",
+      "logs:GetLogGroupFields",
+      "logs:StartQuery",
+      "logs:StopQuery",
+      "logs:GetQueryResults",
+      "logs:GetLogEvents"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "cloudwatch:GetMetricStatistics",
+      "cloudwatch:DescribeAlarmsForMetric",
+      "cloudwatch:DescribeAlarmHistory",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetInsightRuleReport"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "tag:GetResources",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions   = ["sts:AssumeRole"]
+    resources = [aws_iam_role.grafana_role.arn]
+  }
+}
+
+# Create role referencing iam-assumable-role-with-oidc,
+# as "allow_self_assume_role" is only available on latest module which have a dependency of terraform version >1
+# IRSA
+
+locals {
+  aws_account_id = data.aws_caller_identity.current.account_id
+  role_name      = "grafana.${var.cluster_domain_name}"
+}
+
+data "aws_caller_identity" "current" {}
+
+data "aws_iam_policy_document" "assume_role_with_oidc" {
+
+  dynamic "statement" {
+    # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
+
+    content {
+      sid     = "ExplicitSelfRoleAssumption"
+      effect  = "Allow"
+      actions = ["sts:AssumeRole"]
+
+      principals {
+        type        = "AWS"
+        identifiers = ["*"]
+      }
+
+      condition {
+        test     = "ArnLike"
+        variable = "aws:PrincipalArn"
+        values   = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${local.role_name}"]
+      }
+    }
+  }
+
+  dynamic "statement" {
+
+    content {
+      effect  = "Allow"
+      actions = ["sts:AssumeRoleWithWebIdentity"]
+
+      principals {
+        type = "Federated"
+
+        identifiers = ["arn:aws:iam::${local.aws_account_id}:oidc-provider/${eks_cluster_oidc_issuer_url}"]
+      }
+
+      dynamic "condition" {
+
+        content {
+          test     = "StringEquals"
+          variable = "${eks_cluster_oidc_issuer_url}:sub"
+          values   = ["system:serviceaccount:monitoring:prometheus-operator-grafana"]
+        }
+      }
+
+    }
+  }
+}
+
+resource "aws_iam_role" "grafana_role" {
+
+  name                 = "grafana.${var.cluster_domain_name}"
+  description          = "iam-assumable-role-with-oidc"
+  max_session_duration = "3600"
+
+  assume_role_policy = data.aws_iam_policy_document.assume_role_with_oidc.json
+
+  tags = var.tags
+}
+
+resource "aws_iam_role_policy_attachment" "custom" {
+  count = var.create_role ? local.number_of_role_policy_arns : 0
+
+  role       = aws_iam_role.grafana_role.name
+  policy_arn = aws_iam_policy.grafana_datasource.arn
+}

--- a/grafana-role.tf
+++ b/grafana-role.tf
@@ -71,20 +71,16 @@ locals {
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "assume_role_with_oidc" {
-
-  dynamic "statement" {
+  statement {
     # https://aws.amazon.com/blogs/security/announcing-an-update-to-iam-role-trust-policy-behavior/
-
     content {
       sid     = "ExplicitSelfRoleAssumption"
       effect  = "Allow"
       actions = ["sts:AssumeRole"]
-
       principals {
         type        = "AWS"
         identifiers = ["*"]
       }
-
       condition {
         test     = "ArnLike"
         variable = "aws:PrincipalArn"
@@ -92,28 +88,22 @@ data "aws_iam_policy_document" "assume_role_with_oidc" {
       }
     }
   }
-
-  dynamic "statement" {
-
+  statement {
     content {
       effect  = "Allow"
       actions = ["sts:AssumeRoleWithWebIdentity"]
-
       principals {
         type = "Federated"
 
         identifiers = ["arn:aws:iam::${local.aws_account_id}:oidc-provider/${eks_cluster_oidc_issuer_url}"]
       }
-
-      dynamic "condition" {
-
+      condition {
         content {
           test     = "StringEquals"
           variable = "${eks_cluster_oidc_issuer_url}:sub"
           values   = ["system:serviceaccount:monitoring:prometheus-operator-grafana"]
         }
       }
-
     }
   }
 }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -207,9 +207,27 @@ data "aws_iam_policy_document" "grafana_datasource_irsa" {
   }
   statement {
     actions = [
-      "cloudwatch:ListMetrics",
       "cloudwatch:GetMetricStatistics",
-      "cloudwatch:GetMetricData"
+      "cloudwatch:DescribeAlarmsForMetric",
+      "cloudwatch:DescribeAlarmHistory",
+      "cloudwatch:DescribeAlarms",
+      "cloudwatch:ListMetrics",
+      "cloudwatch:GetMetricData",
+      "cloudwatch:GetInsightRuleReport"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "ec2:DescribeTags",
+      "ec2:DescribeInstances",
+      "ec2:DescribeRegions"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "tag:GetResources",
     ]
     resources = ["*"]
   }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -120,7 +120,7 @@ resource "helm_release" "prometheus_operator_eks" {
     prometheus_ingress                         = local.prometheus_ingress
     random_username                            = random_id.username.hex
     random_password                            = random_id.password.hex
-    grafana_assumerolearn                      = module.iam_assumable_role_grafana_datasource.iam_role_arn
+    grafana_assumerolearn                      = aws_iam_role.grafana_role.arn
     clusterName                                = terraform.workspace
     enable_prometheus_affinity_and_tolerations = var.enable_prometheus_affinity_and_tolerations
     enable_thanos_sidecar                      = var.enable_thanos_sidecar
@@ -159,80 +159,6 @@ resource "helm_release" "prometheus_operator_eks" {
 # Ref: https://github.com/evry/docker-oidc-proxy
 resource "random_id" "session_secret" {
   byte_length = 16
-}
-
-######################
-# Grafana Cloudwatch #
-######################
-
-# Grafana datasource for cloudwatch
-# Ref: https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
-
-# Minimal policy permissions 
-# Ref: https://grafana.com/docs/grafana/latest/features/datasources/cloudwatch/#iam-policies
-# IRSA
-
-module "iam_assumable_role_grafana_datasource" {
-  source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "4.24.1"
-  create_role                   = true
-  allow_self_assume_role        = true
-  role_name                     = "grafana.${var.cluster_domain_name}"
-  provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [length(aws_iam_policy.grafana_datasource) >= 1 ? aws_iam_policy.grafana_datasource.arn : ""]
-  oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:prometheus-operator-grafana"]
-
-}
-
-resource "aws_iam_policy" "grafana_datasource" {
-
-  name_prefix = "grafana"
-  description = "EKS grafana datasource policy for cluster ${var.cluster_domain_name}"
-  policy      = data.aws_iam_policy_document.grafana_datasource_irsa.json
-}
-
-data "aws_iam_policy_document" "grafana_datasource_irsa" {
-  statement {
-    actions = [
-      "logs:DescribeLogGroups",
-      "logs:GetLogGroupFields",
-      "logs:StartQuery",
-      "logs:StopQuery",
-      "logs:GetQueryResults",
-      "logs:GetLogEvents"
-    ]
-    resources = ["*"]
-  }
-  statement {
-    actions = [
-      "cloudwatch:GetMetricStatistics",
-      "cloudwatch:DescribeAlarmsForMetric",
-      "cloudwatch:DescribeAlarmHistory",
-      "cloudwatch:DescribeAlarms",
-      "cloudwatch:ListMetrics",
-      "cloudwatch:GetMetricData",
-      "cloudwatch:GetInsightRuleReport"
-    ]
-    resources = ["*"]
-  }
-  statement {
-    actions = [
-      "ec2:DescribeTags",
-      "ec2:DescribeInstances",
-      "ec2:DescribeRegions"
-    ]
-    resources = ["*"]
-  }
-  statement {
-    actions = [
-      "tag:GetResources",
-    ]
-    resources = ["*"]
-  }
-  statement {
-    actions   = ["sts:AssumeRole"]
-    resources = [module.iam_assumable_role_grafana_datasource.this_iam_role_arn]
-  }
 }
 
 # This Ingress is to re-direct "grafana.cloud-platform.service.justice.gov.uk" to grafana_root URL

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -120,9 +120,7 @@ resource "helm_release" "prometheus_operator_eks" {
     prometheus_ingress                         = local.prometheus_ingress
     random_username                            = random_id.username.hex
     random_password                            = random_id.password.hex
-    grafana_pod_annotation                     = module.iam_assumable_role_grafana_datasource.this_iam_role_name
-    grafana_assumerolearn                      = module.iam_assumable_role_grafana_datasource.this_iam_role_arn
-    monitoring_aws_role                        = module.iam_assumable_role_monitoring.this_iam_role_name
+    grafana_assumerolearn                      = module.iam_assumable_role_grafana_datasource.iam_role_arn
     clusterName                                = terraform.workspace
     enable_prometheus_affinity_and_tolerations = var.enable_prometheus_affinity_and_tolerations
     enable_thanos_sidecar                      = var.enable_thanos_sidecar
@@ -130,7 +128,6 @@ resource "helm_release" "prometheus_operator_eks" {
     eks_service_account                        = module.iam_assumable_role_monitoring.this_iam_role_arn
     storage_class                              = can(regex("live", terraform.workspace)) ? "io1-expand" : "gp2-expand"
     storage_size                               = can(regex("live", terraform.workspace)) ? "750Gi" : "75Gi"
-    grafana_version                            = "7.5.9"
   })]
 
   # Depends on Helm being installed
@@ -177,8 +174,9 @@ resource "random_id" "session_secret" {
 
 module "iam_assumable_role_grafana_datasource" {
   source                        = "terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc"
-  version                       = "3.13.0"
+  version                       = "4.24.1"
   create_role                   = true
+  allow_self_assume_role        = true
   role_name                     = "grafana.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
   role_policy_arns              = [length(aws_iam_policy.grafana_datasource) >= 1 ? aws_iam_policy.grafana_datasource.arn : ""]

--- a/templates/cloudwatch-exporter.yaml
+++ b/templates/cloudwatch-exporter.yaml
@@ -60,10 +60,18 @@ config: |-
   - aws_namespace: AWS/S3
     aws_metric_name: BucketSizeBytes
     aws_dimensions: [BucketName, StorageType]
+    aws_statistics: [Average]
+    range_seconds: 172800
+    period_seconds: 86400
+    set_timestamp: false
  
   - aws_namespace: AWS/S3
     aws_metric_name: NumberOfObjects
     aws_dimensions: [BucketName, StorageType]
+    aws_statistics: [Average]
+    range_seconds: 172800
+    period_seconds: 86400
+    set_timestamp: false
 
     # SQS Metrics
   - aws_namespace: AWS/SQS
@@ -122,10 +130,17 @@ config: |-
   - aws_namespace: AWS/SNS
     aws_metric_name: NumberOfNotificationsFilteredOut-NoMessageAttributes
     aws_dimensions: [TopicName]
+    aws_dimensions: [TopicName]
+    aws_namespace: AWS/SNS
+    aws_statistics:
+    - Sum
 
   - aws_namespace: AWS/SNS
     aws_metric_name: NumberOfNotificationsFilteredOut-InvalidAttributes
     aws_dimensions: [TopicName]
+    aws_namespace: AWS/SNS
+    aws_statistics:
+    - Sum
     
   - aws_namespace: AWS/SNS
     aws_metric_name: PublishSize
@@ -182,10 +197,16 @@ config: |-
   - aws_namespace: AWS/DynamoDB
     aws_metric_name: WriteThrottleEvents
     aws_dimensions: ["TableName","GlobalSecondaryIndexName"]
+    aws_namespace: AWS/DynamoDB
+    aws_statistics:
+    - Sum
 
   - aws_namespace: AWS/DynamoDB
     aws_metric_name: ReadThrottleEvents
     aws_dimensions: ["TableName","GlobalSecondaryIndexName"]
+    aws_namespace: AWS/DynamoDB
+    aws_statistics:
+    - Sum
 
     # MQ Broker Metrics
   - aws_namespace: AWS/AmazonMQ

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -196,6 +196,10 @@ alertmanager:
               operator: In
               values:
               - "true"
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - "eu-west-2b"
     %{ endif ~}
 
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
@@ -526,6 +530,10 @@ prometheus:
               operator: In
               values:
               - "true"
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - "eu-west-2b"
     %{ endif ~}
 
     ## Prometheus StorageSpec for persistent data

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -210,8 +210,8 @@ grafana:
         - "${ grafana_ingress }"
 
   env:
-    AWS_ROLE_ARN: "${grafana_assumerolearn}"
-    AWS_REGION: eu-west-2
+    AWS_ROLE_ARN: "${ grafana_assumerolearn }"
+    AWS_REGION: "eu-west-2"
     ASSUME_ROLE_ENABLED: "true"
     GF_SERVER_ROOT_URL: "${ grafana_root }"
     GF_ANALYTICS_REPORTING_ENABLED: "false"
@@ -244,6 +244,10 @@ grafana:
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
+    securityContext:
+      fsGroup: 472
+      runAsUser: 472
+      runAsGroup: 472
     alerts:
       enabled: true
       label: grafana_alert
@@ -267,7 +271,7 @@ grafana:
     editable: true
     access: proxy
     jsonData:
-      authType: arn
+      authType: default
       defaultRegion: eu-west-2
       assumeRoleArn: "${ grafana_assumerolearn }"
     orgId: 1

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -162,7 +162,7 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
-          storageClassName: gp3
+          storageClassName: gp2-expand
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
@@ -172,35 +172,6 @@ alertmanager:
     ##
     externalUrl: "${ alertmanager_ingress }"
 
-    %{ if enable_prometheus_affinity_and_tolerations ~}
-    ## Tolerations for use with node taints
-    ## ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-    ##
-    tolerations:
-      - key: "monitoring-node"
-        operator: "Equal"
-        value: "true"
-        effect: "NoSchedule"
-    %{ endif ~}
-
-    %{ if enable_prometheus_affinity_and_tolerations ~}
-    ## Assign custom affinity rules to the prometheus instance
-    ## ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
-    ##
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-          - matchExpressions:
-            - key: cloud-platform.justice.gov.uk/monitoring-ng
-              operator: In
-              values:
-              - "true"
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-              - "eu-west-2b"
-    %{ endif ~}
 
 ## Using default values from https://github.com/helm/charts/blob/master/stable/grafana/values.yaml
 ##
@@ -530,10 +501,6 @@ prometheus:
               operator: In
               values:
               - "true"
-            - key: topology.kubernetes.io/zone
-              operator: In
-              values:
-              - "eu-west-2b"
     %{ endif ~}
 
     ## Prometheus StorageSpec for persistent data
@@ -542,7 +509,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: gp3
+          storageClassName: ${storage_class}
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -252,7 +252,7 @@ grafana:
     editable: true
     access: proxy
     jsonData:
-      authType: default
+      authType: arn
       defaultRegion: eu-west-2
       assumeRoleArn: "${ grafana_assumerolearn }"
     orgId: 1

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -265,28 +265,52 @@ grafana:
 
   ## Configure additional grafana datasources
   ## ref: http://docs.grafana.org/administration/provisioning/#datasources
-  additionalDataSources:
-  - name: Cloudwatch
-    type: cloudwatch
-    editable: true
-    access: proxy
-    jsonData:
-      authType: default
-      defaultRegion: eu-west-2
-      assumeRoleArn: "${ grafana_assumerolearn }"
-    orgId: 1
-    version: 1
-  - name: Alertmanager
-    type: "camptocamp-prometheus-alertmanager-datasource"
-    url: "http://alertmanager-operated:9093"
-    version: 1
-  - name: Thanos
-    type: "prometheus"
-    url: "http://thanos-query:9090"
-    isDefault: false
-    access: proxy
-    version: 1
+  # additionalDataSources:
+  # - name: Cloudwatch
+  #   type: cloudwatch
+  #   editable: true
+  #   access: proxy
+  #   jsonData:
+  #     authType: default
+  #     defaultRegion: eu-west-2
+  #     assumeRoleArn: "${ grafana_assumerolearn }"
+  #   orgId: 1
+  #   version: 1
+  # - name: Alertmanager
+  #   type: "camptocamp-prometheus-alertmanager-datasource"
+  #   url: "http://alertmanager-operated:9093"
+  #   version: 1
+  # - name: Thanos
+  #   type: "prometheus"
+  #   url: "http://thanos-query:9090"
+  #   isDefault: false
+  #   access: proxy
+  #   version: 1
 
+  datasources:
+    datasources.yaml:
+      apiVersion: 1
+      datasources:
+        - name: Cloudwatch
+          type: cloudwatch
+          editable: true
+          access: proxy
+          jsonData:
+            authType: default
+            defaultRegion: eu-west-2
+            assumeRoleArn: "${ grafana_assumerolearn }"
+          orgId: 1
+          version: 1
+        - name: Alertmanager
+          type: "camptocamp-prometheus-alertmanager-datasource"
+          url: "http://alertmanager-operated:9093"
+          version: 1
+        - name: Thanos
+          type: "prometheus"
+          url: "http://thanos-query:9090"
+          isDefault: false
+          access: proxy
+          version: 1
 ## Component scraping coreDns. Use either this or kubeDns
 ##
 coreDns:

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -184,7 +184,6 @@ grafana:
     pullSecrets:
     - "dockerhub-credentials"
     repository: grafana/grafana
-    tag: ${grafana_version}
     pullPolicy: IfNotPresent
 
   serviceAccount:
@@ -210,6 +209,12 @@ grafana:
       - hosts:
         - "${ grafana_ingress }"
 
+  plugins:
+    - digrich-bubblechart-panel
+    - grafana-clock-panel
+    - mtanda-histogram-panel
+    - grafana-worldmap-panel
+
   env:
     GF_SERVER_ROOT_URL: "${ grafana_root }"
     GF_ANALYTICS_REPORTING_ENABLED: "false"
@@ -227,13 +232,17 @@ grafana:
 
   envFromSecret: "grafana-env"
 
-  serverDashboardConfigmaps:
+  dashboardsConfigMaps:
     - grafana-user-dashboards
 
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
-      tag: 1.14.2
+    alerts:
+      enabled: true
+      label: grafana_alert
+      labelValue: ""
+      searchNamespace: ALL
     dashboards:
       enabled: true
       label: grafana_dashboard

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -232,9 +232,6 @@ grafana:
 
   envFromSecret: "grafana-env"
 
-  dashboardsConfigMaps:
-    - grafana-user-dashboards
-
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -162,7 +162,7 @@ alertmanager:
     storage:
       volumeClaimTemplate:
         spec:
-          storageClassName: gp2-expand
+          storageClassName: gp3
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:
@@ -534,7 +534,7 @@ prometheus:
     storageSpec:
       volumeClaimTemplate:
         spec:
-          storageClassName: ${storage_class}
+          storageClassName: gp3
           accessModes: ["ReadWriteOnce"]
           resources:
             requests:

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -300,15 +300,15 @@ kubeEtcd:
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
-  enabled: true
+  enabled: false
 
 kubeProxy:
-  enabled: true
+  enabled: false
 
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
-  enabled: true
+  enabled: false
 
   ## If using kubeControllerManager.endpoints only the port and targetPort are used
   ##

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -235,6 +235,9 @@ grafana:
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
+    securityContext:
+    # skipTlsVerify Set to true to skip tls verification for kube api calls
+      skipTlsVerify: true
     alerts:
       enabled: true
       label: grafana_alert

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -210,6 +210,9 @@ grafana:
         - "${ grafana_ingress }"
 
   env:
+    AWS_ROLE_ARN: "${grafana_assumerolearn}"
+    AWS_REGION: eu-west-2
+    ASSUME_ROLE_ENABLED: "true"
     GF_SERVER_ROOT_URL: "${ grafana_root }"
     GF_ANALYTICS_REPORTING_ENABLED: "false"
     GF_AUTH_DISABLE_LOGIN_FORM: "true"
@@ -225,6 +228,18 @@ grafana:
     GF_AUTH_GENERIC_OAUTH_SCOPES: "openid profile email"
 
   envFromSecret: "grafana-env"
+
+  extraSecretMounts:
+  - name: aws-iam-token
+    mountPath: /var/run/secrets/eks.amazonaws.com/serviceaccount
+    readOnly: true
+    projected:
+      defaultMode: 420
+      sources:
+        - serviceAccountToken:
+            audience: sts.amazonaws.com
+            expirationSeconds: 86400
+            path: token
 
   sidecar:
     image:

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -244,10 +244,6 @@ grafana:
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
-    securityContext:
-      fsGroup: 472
-      runAsUser: 472
-      runAsGroup: 472
     alerts:
       enabled: true
       label: grafana_alert

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -209,12 +209,6 @@ grafana:
       - hosts:
         - "${ grafana_ingress }"
 
-  # plugins:
-  #   - digrich-bubblechart-panel
-  #   - grafana-clock-panel
-  #   - mtanda-histogram-panel
-  #   - grafana-worldmap-panel
-
   env:
     GF_SERVER_ROOT_URL: "${ grafana_root }"
     GF_ANALYTICS_REPORTING_ENABLED: "false"
@@ -235,9 +229,6 @@ grafana:
   sidecar:
     image:
       repository: quay.io/kiwigrid/k8s-sidecar
-    securityContext:
-    # skipTlsVerify Set to true to skip tls verification for kube api calls
-      skipTlsVerify: true
     alerts:
       enabled: true
       label: grafana_alert
@@ -290,15 +281,15 @@ kubeEtcd:
 ## Component scraping kube scheduler
 ##
 kubeScheduler:
-  enabled: false
+  enabled: true
 
 kubeProxy:
-  enabled: false
+  enabled: true
 
 ## Component scraping the kube controller manager
 ##
 kubeControllerManager:
-  enabled: false
+  enabled: true
 
   ## If using kubeControllerManager.endpoints only the port and targetPort are used
   ##

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -209,11 +209,11 @@ grafana:
       - hosts:
         - "${ grafana_ingress }"
 
-  plugins:
-    - digrich-bubblechart-panel
-    - grafana-clock-panel
-    - mtanda-histogram-panel
-    - grafana-worldmap-panel
+  # plugins:
+  #   - digrich-bubblechart-panel
+  #   - grafana-clock-panel
+  #   - mtanda-histogram-panel
+  #   - grafana-worldmap-panel
 
   env:
     GF_SERVER_ROOT_URL: "${ grafana_root }"


### PR DESCRIPTION
This PR has the following.
- Upgrade cloudwatch-exporter and iam-assumable-role-with-oidc used by cloudwatch-exporter
- Maintain IRSA(iam-assumable-role-with-oidc) module locally as the latest self assumed role has a dependency on terraform version
- Upgrade grafana
- Move grafana to the manager node group
- Upgrade grafana sidecar.