### PR TITLE
Refactor to meet standardised Terraform structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,19 +30,25 @@ module "monitoring" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >=4.24.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.6.0 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >=3.2.1 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >=1.13.2 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >=2.12.1 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >=3.4.3 |
+| <a name="requirement_template"></a> [template](#requirement\_template) | >=2.2.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6.0 |
-| <a name="provider_http"></a> [http](#provider\_http) | n/a |
-| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | n/a |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
-| <a name="provider_random"></a> [random](#provider\_random) | n/a |
-| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >=4.24.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.6.0 |
+| <a name="provider_http"></a> [http](#provider\_http) | >=3.2.1 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >=1.13.2 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >=2.12.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | >=3.4.3 |
+| <a name="provider_template"></a> [template](#provider\_template) | >=2.2.0 |
 
 ## Modules
 
@@ -121,8 +127,6 @@ module "monitoring" {
 | <a name="input_enable_thanos_compact"></a> [enable\_thanos\_compact](#input\_enable\_thanos\_compact) | Enable or not Thanos Compact - not semantically concurrency safe and must be deployed as a singleton against a bucket | `bool` | `false` | no |
 | <a name="input_enable_thanos_helm_chart"></a> [enable\_thanos\_helm\_chart](#input\_enable\_thanos\_helm\_chart) | Enable or not Thanos Helm Chart - (do NOT confuse this with thanos sidecar within prometheus-operator) | `bool` | `false` | no |
 | <a name="input_enable_thanos_sidecar"></a> [enable\_thanos\_sidecar](#input\_enable\_thanos\_sidecar) | Enable or not Thanos sidecar. Basically defines if we want to send cluster metrics to thanos's S3 bucket | `bool` | `false` | no |
-| <a name="input_grafana_ingress_redirect_url"></a> [grafana\_ingress\_redirect\_url](#input\_grafana\_ingress\_redirect\_url) | grafana url to use live\_domain, 'cloud-platform.service.justice.gov.uk' | `string` | `""` | no |
-| <a name="input_ingress_redirect"></a> [ingress\_redirect](#input\_ingress\_redirect) | Enable ingress\_redirect, to use live\_domain, 'cloud-platform.service.justice.gov.uk' | `bool` | `false` | no |
 | <a name="input_kibana_audit_upstream"></a> [kibana\_audit\_upstream](#input\_kibana\_audit\_upstream) | ES upstream for audit logs | `string` | `""` | no |
 | <a name="input_kibana_upstream"></a> [kibana\_upstream](#input\_kibana\_upstream) | ES upstream for logs | `string` | `""` | no |
 | <a name="input_oidc_components_client_id"></a> [oidc\_components\_client\_id](#input\_oidc\_components\_client\_id) | OIDC ClientID used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |

--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -46,7 +46,7 @@ module "iam_assumable_role_cloudwatch_exporter" {
   create_role                   = var.enable_cloudwatch_exporter ? true : false
   role_name                     = "cloudwatch.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.enable_cloudwatch_exporter ? aws_iam_policy.cloudwatch_exporter.0.arn : ""]
+  role_policy_arns              = [var.enable_cloudwatch_exporter ? aws_iam_policy.cloudwatch_exporter[0].arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:cloud-platform-cloudwatch-exporter"]
 }
 

--- a/ecr-exporter.tf
+++ b/ecr-exporter.tf
@@ -56,7 +56,7 @@ module "iam_assumable_role_ecr_exporter" {
   create_role                   = var.enable_ecr_exporter ? true : false
   role_name                     = "ecr-exporter.${var.cluster_domain_name}"
   provider_url                  = var.eks_cluster_oidc_issuer_url
-  role_policy_arns              = [var.enable_ecr_exporter ? aws_iam_policy.ecr_exporter.0.arn : ""]
+  role_policy_arns              = [var.enable_ecr_exporter ? aws_iam_policy.ecr_exporter[0].arn : ""]
   oidc_fully_qualified_subjects = ["system:serviceaccount:monitoring:default"]
 }
 

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -86,8 +86,8 @@ EOS
 }
 
 
-// Prometheus crd yaml pulled from kube-prometheus-stack helm chart. 
-// Upate variable `prometheus_operator_crd_version` to manage the crd version
+# Prometheus crd yaml pulled from kube-prometheus-stack helm chart.
+# Upate variable `prometheus_operator_crd_version` to manage the crd version
 data "http" "prometheus_crd_yamls" {
   for_each = local.prometheus_crd_yamls
   url      = each.value
@@ -99,8 +99,8 @@ resource "kubectl_manifest" "prometheus_operator_crds" {
   yaml_body         = each.value["body"]
 }
 
-// NOTE: Make sure to update the correct CRD version(if required) using above resource
-// `kubectl_manifest.prometheus_operator_crds` before upgrading prometheus operator
+# NOTE: Make sure to update the correct CRD version(if required) using above resource
+# `kubectl_manifest.prometheus_operator_crds` before upgrading prometheus operator
 resource "helm_release" "prometheus_operator_eks" {
 
   name       = "prometheus-operator"
@@ -108,15 +108,15 @@ resource "helm_release" "prometheus_operator_eks" {
   chart      = "kube-prometheus-stack"
   namespace  = kubernetes_namespace.monitoring.id
   version    = "41.9.1"
-  skip_crds  = true // Crds are managed seperately using resource kubectl_manifest.prometheus_operator_crds
+  skip_crds  = true # Crds are managed seperately using resource kubectl_manifest.prometheus_operator_crds
 
   values = [templatefile("${path.module}/templates/prometheus-operator-eks.yaml.tpl", {
     alertmanager_ingress                       = local.alertmanager_ingress
     grafana_ingress                            = local.grafana_ingress
     grafana_root                               = local.grafana_root
     pagerduty_config                           = var.pagerduty_config
-    alertmanager_routes                        = join("", data.template_file.alertmanager_routes.*.rendered)
-    alertmanager_receivers                     = join("", data.template_file.alertmanager_receivers.*.rendered)
+    alertmanager_routes                        = join("", data.template_file.alertmanager_routes[*].rendered)
+    alertmanager_receivers                     = join("", data.template_file.alertmanager_receivers[*].rendered)
     prometheus_ingress                         = local.prometheus_ingress
     random_username                            = random_id.username.hex
     random_password                            = random_id.password.hex

--- a/variables.tf
+++ b/variables.tf
@@ -71,11 +71,6 @@ variable "oidc_issuer_url" {
   description = "Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy)"
 }
 
-variable "ingress_redirect" {
-  description = "Enable ingress_redirect, to use live_domain, 'cloud-platform.service.justice.gov.uk'"
-  type        = bool
-  default     = false
-}
 variable "eks_cluster_oidc_issuer_url" {
   description = "This is going to be used when we create the IAM OIDC role"
   type        = string
@@ -108,12 +103,6 @@ variable "kibana_upstream" {
 
 variable "kibana_audit_upstream" {
   description = "ES upstream for audit logs"
-  default     = ""
-  type        = string
-}
-
-variable "grafana_ingress_redirect_url" {
-  description = "grafana url to use live_domain, 'cloud-platform.service.justice.gov.uk'"
   default     = ""
   type        = string
 }

--- a/versions.tf
+++ b/versions.tf
@@ -1,23 +1,32 @@
 terraform {
   required_providers {
     aws = {
-      source = "hashicorp/aws"
+      source  = "hashicorp/aws"
+      version = ">=4.24.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.6.0"
+      version = ">=2.6.0"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">=3.2.1"
     }
     kubernetes = {
-      source = "hashicorp/kubernetes"
+      source  = "hashicorp/kubernetes"
+      version = ">=2.12.1"
     }
     random = {
-      source = "hashicorp/random"
+      source  = "hashicorp/random"
+      version = ">=3.4.3"
     }
     template = {
-      source = "hashicorp/template"
+      source  = "hashicorp/template"
+      version = ">=2.2.0"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
+      version = ">=1.13.2"
     }
   }
   required_version = ">= 0.14"


### PR DESCRIPTION
This PR:

- replaces legacy dot syntax with square bracket notation
- removes legacy `//` comments with `#` comments
- removes unused variables `ingress_redirect` and `grafana_ingress_redirect_url`
- pins minimum provider versions