### PR TITLE
Add AWS Node zone affinity for Prometheus Operator

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -501,6 +501,12 @@ prometheus:
               operator: In
               values:
               - "true"
+          - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+              - "eu-west-2b"
+
     %{ endif ~}
 
     ## Prometheus StorageSpec for persistent data


### PR DESCRIPTION
Add AWS Node zone affinity for Prometheus Operator

This is to solve an issue on 1.23 where the pod does not get scheduled in the correct/same zone as the PV without having a zone affinity assigned. 