### PR TITLE
alert-only-for-missing-namespaces-and-not-issues-with-kuberhealthy-itself

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -410,7 +410,7 @@ spec:
         message: One of the following vital namespaces no longer exists - "cert-manager", "default", "ingress-controllers", "kube-system", "logging", "monitoring", "opa", "velero", "kubectl -n kuberhealthy describe khstate namespace-kh-check". Also check failing pod logs.
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-kuberhealthy/tree/main/cmd/namespace-check/README.md
       expr: |-
-        kuberhealthy_check{check="kuberhealthy/namespace-kh-check", container="kuberhealthy", endpoint="http", exported_namespace="kuberhealthy",  job="kuberhealthy", namespace="kuberhealthy",  service="kuberhealthy", status!="1"}
+        kuberhealthy_check{container="kuberhealthy",endpoint="http",exported_namespace="kuberhealthy",job="kuberhealthy",namespace="kuberhealthy",service="kuberhealthy",status!="1",error=~"Namespace check failed:missing namespaces:.+"}
       for: 1m
       labels:
         severity: warning


### PR DESCRIPTION
Why:
[Kuberhealthy Alerts Review#4670](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4670)

Ammeded query to catch all namespace missing combinations (REGEX corrected):
`kuberhealthy_check{container="kuberhealthy",endpoint="http",exported_namespace="kuberhealthy",job="kuberhealthy",namespace="kuberhealthy",service="kuberhealthy",status!="1",error=~"Namespace check failed:missing namespaces:.+"}`
See:
1 missing namespace (velero)
[cp-0210-0717](https://prometheus.cp-0210-0717.cloud-platform.service.justice.gov.uk/graph?g0.expr=kuberhealthy_check%7Bcontainer%3D%22kuberhealthy%22%2Cendpoint%3D%22http%22%2Cexported_namespace%3D%22kuberhealthy%22%2Cjob%3D%22kuberhealthy%22%2Cnamespace%3D%22kuberhealthy%22%2Cservice%3D%22kuberhealthy%22%2Cstatus!%3D%221%22%2Cerror%3D~%22Namespace%20check%20failed%3Amissing%20namespaces%3A.%2B%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h)
or
2. 2 missing namespaces (cert-manager,velero)
[cp-0210-1602](https://prometheus.cp-0210-1602.cloud-platform.service.justice.gov.uk/graph?g0.expr=kuberhealthy_check%7Bcontainer%3D%22kuberhealthy%22%2Cendpoint%3D%22http%22%2Cexported_namespace%3D%22kuberhealthy%22%2Cjob%3D%22kuberhealthy%22%2Cnamespace%3D%22kuberhealthy%22%2Cservice%3D%22kuberhealthy%22%2Cstatus!%3D%221%22%2Cerror%3D~%22Namespace%20check%20failed%3Amissing%20namespaces%3A.%2B%22%7D&g0.tab=1&g0.stacked=0&g0.show_exemplars=0&g0.range_input=1h)

