### PR TITLE
chore: 🤖 add prometheus server memory alert

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -414,3 +414,12 @@ spec:
       for: 1m
       labels:
         severity: warning
+    - alert: PrometheusServerMemHigh
+      annotations:
+        message: The Prometheus server uses a lot of memory and has ocassionally OOMKilled bringing down prometheus. Bump the node group monitoring instance size
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3dc05e588c9115c7aa44c2a9b5e26feff985f965
+      expr: |-
+        sum(container_memory_working_set_bytes{namespace="monitoring", pod="prometheus-prometheus-operator-kube-p-prometheus-0", container="prometheus"}) / sum(kube_pod_container_resource_limits{namespace="monitoring", pod="prometheus-prometheus-operator-kube-p-prometheus-0", resource="memory", container="prometheus"}) * 100 > 80
+      for: 5m
+      labels:
+        severity: warning


### PR DESCRIPTION
In response to the Prometheus server being oom killed, we need an alert to notify us beforehand so we can act and bump the size of the instance.