### PR TITLE
Adjust liveness and readiness probe timout and periodseconds

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -420,6 +420,17 @@ prometheus:
         effect: "NoSchedule"
     %{ endif ~}
 
+    # Adjust the liveness and readiness probe to accomodate slow prometheus until investigating
+    # the cause of the slowness
+    containers:
+    - name: prometheus
+      livenessProbe:
+        periodSeconds: 8
+        timeoutSeconds: 6
+      readinessProbe:
+        periodSeconds: 8
+        timeoutSeconds: 6
+
     ## External labels to add to any time series or alerts when communicating with external systems
     ##    
     externalLabels:


### PR DESCRIPTION
This PR adds custom liveness and readiness probe to prometheus container.

The prometheus restarted few times in past days and while investigating its the readiness probe failed with 503. The prometheus is slow is responding sometimes due to having more data, more scrape and more serviceMonitors. Until we find the solution to handle, Increasing the timeoutSeconds from 3(default from chart) to 6 will allow slow prometheus to respond to probe before it is considered as failure.
This PR also changes the periodSeconds from 5 to 8 so the probe doesnt start before the previous one is finished. 