### PR TITLE
remove-superfluous-KuberhealthyOverallClusterStateCheck-alert

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -396,15 +396,6 @@ spec:
       for: 1m
       labels:
         severity: warning
-    - alert: KuberhealthyOverallClusterStateCheck
-      annotations:
-        message: Check for any Kuberhealthy checks with status "fail". "kubectl -n kuberhealthy get khstate". Also check failing pod logs.
-        runbook_url: https://github.com/kuberhealthy/kuberhealthy
-      expr: |-
-        kuberhealthy_cluster_state!=1
-      for: 1m
-      labels:
-        severity: warning
     - alert: KuberhealthyNamespaceExistsCheck
       annotations:
         message: One of the following vital namespaces no longer exists - "cert-manager", "default", "ingress-controllers", "kube-system", "logging", "monitoring", "opa", "velero", "kubectl -n kuberhealthy describe khstate namespace-kh-check". Also check failing pod logs.


### PR DESCRIPTION
Why:
[KuberhealthyOverallClusterStateCheck Alert - output information as to which of the Kuberhealthy alerts has failed#4844](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4844):
In my opinion we alerted by Kuberhealthy too much:

We have 4 Kuberhealthy checks:

1. **daemonset** - alert `KuberhealthyDaemonsetCheck`
2. **deployment**- alert `KuberhealthyDeploymentCheck`
3. **dns-status-internal** - alert `KuberhealthyDNSStatusCheckInternal`
4. **namespace-kh-check**- alert `KuberhealthyNamespaceExistsCheck`

For 1, 2 and 3 above, we are at present alerted twice (once for their respective alerts, plus the `KuberhealthyOverallClusterStateCheck` alert).

For 4 above. At present we mainly only get 1 alert - `KuberhealthyOverallClusterStateCheck`.
The reason for this is that for all four of these checks we get alerts when there are problems with Kuberhealthy itself. 
A while back I created a specfic alert for namespace  (No 4)- where if any of these namespaces ("cert-manager", "default", "ingress-controllers", "kube-system", "logging", "monitoring", "opa", "velero") are missing we would get a specific alert.
However `KuberhealthyOverallClusterStateCheck` is still alerting where there is a problem with the pod (not where one of those namespaces is missing.
i.e
```
namespace-kh-check-1700456394    0/1     Error        0          4h48m
namespace-kh-check-1700456994    0/1     Error        0          4h38m
namespace-kh-check-1700458194    0/1      Error        0          4h18m
namespace-kh-check-1700459994    0/1     Error        0          3h48m
```
If any of the specific namespaces are missing then we would at present 2 alerts (the specific alert + `KuberhealthyOverallClusterStateCheck`)

The aim after getting rid of `KuberhealthyOverallClusterStateCheck` is to get specific checks for 1, 2 and 3 above
