### PR TITLE
tweak low-priority rootvol high trigger value

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -347,11 +347,11 @@ $ kubectl logs <nginx-ingress-container> -n nginx-controllers
 RootVolUtilisation-High
 Severity: warning
 ```
-This alert is triggered when the root volume has 85% of the capacity used
+This alert is triggered when the root volume has 90% of the capacity used
 
 Expression:
 ```
-expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
+expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >90
 for: 5m
 ```
 

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -133,7 +133,7 @@ spec:
         severity: warning
 
     - alert: RootVolUtilisation-High
-      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >85
+      expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >90
       for: 5m
       labels:
         severity: warning


### PR DESCRIPTION
Adjusting this value and observing. Default garbage collection is triggered at 85% volume usage - the same value as this alert trigger. GC can require several attempts to free up space. 