### PR TITLE
remove-kuberhealthy-dns-status-alert

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -386,16 +386,6 @@ spec:
       for: 1m
       labels:
         severity: warning
-    - alert: KuberhealthyDNSStatusCheckInternal
-      annotations:
-        message: Checks for failures with DNS, including resolving within the cluster "kubectl -n kuberhealthy describe khstate dns-status-internal". 
-          Also check failing checker pod logs.
-        runbook_url: https://github.com/kuberhealthy/kuberhealthy/blob/master/cmd/dns-resolution-check/README.md
-      expr: |-
-        kuberhealthy_check{check="kuberhealthy/dns-status-internal", container="kuberhealthy", endpoint="http", exported_namespace="kuberhealthy",  job="kuberhealthy", namespace="kuberhealthy",  service="kuberhealthy", status!="1"}
-      for: 1m
-      labels:
-        severity: warning
     - alert: KuberhealthyNamespaceExistsCheck
       annotations:
         message: One of the following vital namespaces no longer exists - "cert-manager", "default", "ingress-controllers", "kube-system", "logging", "monitoring", "opa", "velero", "kubectl -n kuberhealthy describe khstate namespace-kh-check". Also check failing pod logs.


### PR DESCRIPTION
Why:
[KuberhealthyOverallClusterStateCheck Alert - output information as to which of the Kuberhealthy alerts has failed#4844](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/gh/ministryofjustice/cloud-platform/4844)
Also with reference to new ticket:
[KuberhealthyDNSStatusCheck (dns-status)- investigate whether we need - Internal and/or External #5035](https://github.com/ministryofjustice/cloud-platform/issues/5035).
Basically the actual check: `dns-status-internal- has not been been customised for our own use, and it is at present only reporting on Kuberhealthy itself. Ticket above therefore to investigate whether this (and or External DNS check) are needed - if yes customise and revisit the alert.