### PR TITLE
bump kube-state-metrics image to v2.7.0

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -332,6 +332,20 @@ kubeStateMetrics:
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
+##
+## ----------------------------------------------------------------
+## NOTE: overriding kube-state-metrics default image tag from v.2.6.0 to v2.7.0 for kube-prometheus-stack chart version 41.9.1 is a temporary measure to workaround
+## autoscaling/v2/beta2 removal in EKS 1.26. Once we start upgrading the whole module, the following image: section can be removed. 
+## See:
+## - https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix
+## - https://github.com/kubernetes/kube-state-metrics/releases/tag/v2.7.0
+##    
+  image:
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
+    tag: v2.7.0  
+##
+## -----------------------------------------------------------------  
+
   metricAnnotationsAllowList:
     - namespaces=[*]
 


### PR DESCRIPTION
this ensures 1.26 cluster upgrade will not introduce errors for kube-state-metrics `autoscaling/v2beta2` requests

