### PR TITLE
Bump cloudwatch-exporter to 0.23.0 and add warn_on_empty_list_dimensions

### DIFF
--- a/cloudwatch-exporter.tf
+++ b/cloudwatch-exporter.tf
@@ -7,7 +7,7 @@ resource "helm_release" "cloudwatch_exporter" {
   name       = "cloudwatch-exporter"
   namespace  = kubernetes_namespace.monitoring.id
   repository = "https://prometheus-community.github.io/helm-charts"
-  version    = "0.22.0"
+  version    = "0.23.0"
   chart      = "prometheus-cloudwatch-exporter"
 
   values = [templatefile("${path.module}/templates/cloudwatch-exporter.yaml", {

--- a/templates/cloudwatch-exporter.yaml
+++ b/templates/cloudwatch-exporter.yaml
@@ -22,6 +22,7 @@ config: |-
   region: eu-west-2
   period_seconds: 240
   set_timestamp: false
+  warn_on_empty_list_dimensions: true
   metrics:
   # RDS Metrics
   - aws_namespace: AWS/RDS


### PR DESCRIPTION
This is a minor version bump for the cloudwatch-exporter from 0.15.0 to 0.15.1

Info here - https://github.com/prometheus/cloudwatch_exporter/releases/tag/v0.15.1