### PR TITLE
Revert "⏫ upgrade `kube-prometheus-stack` to 51.1.1"

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ module "monitoring" {
 | <a name="input_oidc_components_client_secret"></a> [oidc\_components\_client\_secret](#input\_oidc\_components\_client\_secret) | OIDC ClientSecret used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | <a name="input_pagerduty_config"></a> [pagerduty\_config](#input\_pagerduty\_config) | Add PagerDuty key to allow integration with a PD service. | `any` | n/a | yes |
-| <a name="input_prometheus_operator_crd_version"></a> [prometheus\_operator\_crd\_version](#input\_prometheus\_operator\_crd\_version) | The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module | `string` | `"v0.68.0"` | no |
+| <a name="input_prometheus_operator_crd_version"></a> [prometheus\_operator\_crd\_version](#input\_prometheus\_operator\_crd\_version) | The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module | `string` | `"v0.60.1"` | no |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | n/a | `string` | `"webops"` | no |
 
 ## Outputs

--- a/locals.tf
+++ b/locals.tf
@@ -32,10 +32,8 @@ locals {
     alertmanagers        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_alertmanagers.yaml"
     podmonitors          = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml"
     probes               = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml"
-    prometheusagents     = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusagents.yaml"
     prometheuses         = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheuses.yaml"
     prometheusrules      = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_prometheusrules.yaml"
-    scrapeconfigs        = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml"
     servicemonitors      = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml"
     thanosrulers         = "https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/${var.prometheus_operator_crd_version}/example/prometheus-operator-crd/monitoring.coreos.com_thanosrulers.yaml"
   }

--- a/prometheus.tf
+++ b/prometheus.tf
@@ -107,7 +107,7 @@ resource "helm_release" "prometheus_operator_eks" {
   repository = "https://prometheus-community.github.io/helm-charts"
   chart      = "kube-prometheus-stack"
   namespace  = kubernetes_namespace.monitoring.id
-  version    = "51.1.1"
+  version    = "41.9.1"
   skip_crds  = true # Crds are managed seperately using resource kubectl_manifest.prometheus_operator_crds
   timeout    = 600
 

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -340,8 +340,7 @@ kube-state-metrics:
 ## - https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix
 ##    
   image:
-    registry: registry.k8s.io
-    repository: kube-state-metrics/kube-state-metrics
+    repository: registry.k8s.io/kube-state-metrics/kube-state-metrics
     tag: v2.9.2
 ##
 ## -----------------------------------------------------------------  

--- a/variables.tf
+++ b/variables.tf
@@ -96,7 +96,7 @@ variable "kibana_upstream" {
 }
 
 variable "prometheus_operator_crd_version" {
-  default     = "v0.68.0"
+  default     = "v0.60.1"
   description = "The version of the prometheus operator crds matching the prometheus chart that is installed in monitoring module"
 }
 


### PR DESCRIPTION
Realised `51.1.1` is not the latest of the 51.x. `51.10.0` is the latest of 51.x major release version