### PR TITLE
chore: 🤖 remove kube-state-metrics override pin

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -333,20 +333,6 @@ kubeStateMetrics:
 ## Configuration for kube-state-metrics subchart
 ##
 kube-state-metrics:
-##
-## ----------------------------------------------------------------
-## NOTE: overriding kube-state-metrics default image tag from v.2.6.0 to v2.9.2 for kube-prometheus-stack chart version 41.9.1 is a temporary measure to workaround
-## autoscaling/v2/beta2 removal in EKS 1.26. Once we start upgrading the whole module, the following image: section can be removed. 
-## See:
-## - https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix
-##    
-  image:
-    registry: registry.k8s.io
-    repository: kube-state-metrics/kube-state-metrics
-    tag: v2.9.2
-##
-## -----------------------------------------------------------------  
-
   metricAnnotationsAllowList:
     - namespaces=[*]
 


### PR DESCRIPTION
Our current chart version is 56.21.4 and inside there, the [default `kube-state-metrics` chart is 2.10.1](https://github.com/prometheus-community/helm-charts/blob/fd6b0073754fcd0646ebe2c52662d62b15536c8c/charts/kube-state-metrics/values.yaml#L6) which is what is required for our [k8s version of 1.27](https://github.com/kubernetes/kube-state-metrics?tab=readme-ov-file#compatibility-matrix)