### PR TITLE
assiging max time for startup probe for WAL replay

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -444,6 +444,8 @@ prometheus:
         periodSeconds: 15
         timeoutSeconds: 12
 
+    maximumStartupDurationSeconds: 900
+
     ## External labels to add to any time series or alerts when communicating with external systems
     ##    
     externalLabels:


### PR DESCRIPTION
https://github.com/prometheus-community/helm-charts/blob/main/charts/kube-prometheus-stack/values.yaml#L3988