### PR TITLE
Increase cpu, memory requests for prometheus pod to required usage

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -460,8 +460,8 @@ prometheus:
     %{ if enable_large_nodesgroup }
     resources:
       requests:
-        memory: "14000Mi"
-        cpu: "1300m"
+        memory: "180000Mi"
+        cpu: "4000m"
       limits:
         memory: "320000Mi"
         cpu: "28000m"


### PR DESCRIPTION
Prometheus-server pod has affinity and schedule on its own node. The usage of cpu and memory is high and doesnt match the requests. Increase the cpu and memory to match the usual usage of the container.

This is also to check if this  reduces the WAL replay time during startup