### PR TITLE
:wrench:alert for CPU throttling on canary app

### DIFF
--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -416,7 +416,7 @@ spec:
     - alert: CanaryAppCPUHigh
       annotations:
         message: CPU throttling detected in the {{ $labels.namespace }} namespace. Please investigate and increase CPU limts if neccesary. 
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-infrastructure/commit/3dc05e588c9115c7aa44c2a9b5e26feff985f965
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-environments/pull/22575/commits/d821477fa2b30649a12573ae0a5eecced7fbb213
       expr: |-
         sum(node_namespace_pod_container:container_cpu_usage_seconds_total:sum_irate{namespace="cloud-platform-canary-app-eks"}) / sum(kube_pod_container_resource_limits{ namespace="cloud-platform-canary-app-eks", resource="cpu"}) * 100 > 80
       for: 5m


### PR DESCRIPTION
Adds alerting rule of the CPU usage exceeding 80% of the allocated CPU resources in the canary app namespace.

This is related to this [ticketed issue](https://github.com/ministryofjustice/cloud-platform/issues/5399).