### PR TITLE
Split Nginx alert into seperate PrometheusRule and fix expressions

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -536,6 +536,31 @@ The are a number of severity levels that can be defined in the error_log. The fo
 + alert - Prompt action is required.
 + emerg - The system is in an unusable state and requires immediate attention.
 
+## Nginx Success rate
+
+```
+NginxIngressSuccessRate-default-ingress
+Severity: warning
+```
+
+This alert is triggered when the nginx controller pods are sending a non 4xx|5xx responses at a rate less than 95%.
+
+
+Expression:
+```
+sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 95
+```
+
+### Action
+
+There has been previous situations when the response rate was improved when the number of replicas of ingress controller are incremented.
+
+Check in grafana dashboard if the number of requests are increased in past few months. 
+
+NOTE: Currently the ingress controller handles 23.0million requests with success rate at 98.9% over 3 hours period with 30 replicas. If the traffic has increased with the similar time period, the reduced success rate might be because of the number of ingress controller pods.
+
+
 ## Kube API Latency Warning
 
 ```

--- a/resources/prometheusrule-alerts/application-alerts.yaml
+++ b/resources/prometheusrule-alerts/application-alerts.yaml
@@ -413,6 +413,14 @@ spec:
       for: 2m
       labels:
         severity: critical
+    - alert: External-DNSDown
+      expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations: 
+        message: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#kubednsdown
     - alert: CanaryAppCPUHigh
       annotations:
         message: CPU throttling detected in the {{ $labels.namespace }} namespace. Please investigate and increase CPU limts if neccesary. 

--- a/resources/prometheusrule-alerts/nginx-alerts.yaml
+++ b/resources/prometheusrule-alerts/nginx-alerts.yaml
@@ -1,0 +1,170 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  labels:
+    prometheus: ingress-controller
+  name: ingress-controller-apps.rules
+spec:
+  groups:
+  - name: nginx-ingress-controller-apps
+    rules:
+    - alert: NginxIngress-Latency(ms)-modsec-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"nginx-ingress-modsec.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"nginx-ingress-modsec.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - modsec ingress -latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+    - alert: NginxIngress-Latency(ms)-default-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"nginx-ingress-default.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"nginx-ingress-default.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - nginx-ingress-default ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+    - alert: NginxIngress-Latency(ms)-production-only-ingress-High
+      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"nginx-ingress-production-only.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"nginx-ingress-production-only.*"}[5m])) * 1000 > 300
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        message: '{{ $labels.pod}} - production only ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
+
+    - alert: NginxConfigReloadFailureWarning
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-config-reload-failure
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 3m
+      labels:
+        severity: warning
+    - alert: NginxConfigReloadFailure
+      annotations:
+        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-config-reload-failure:x
+      expr: nginx_ingress_controller_config_last_reload_successful == 0
+      for: 5m
+      labels:
+        severity: critical
+    - alert: NginxIngressPodDown-default-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-default-controller-.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressPodDown-modsec-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more modsec nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-modsec.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressPodDown-production-only-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more production-only nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-production-only.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressDown-default-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          5 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-default-.*"})>
+        5
+      for: 5m
+      labels:
+        severity: critical
+
+    - alert: NginxIngressDown-modsec-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          3 or more modsec nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-modsec.*"})>
+        3
+      for: 5m
+      labels:
+        severity: critical
+  
+    - alert: NginxIngressDown-production-only-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          3 or more production-only nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-production-only.*"})>
+        3
+      for: 5m
+      labels:
+        severity: critical
+
+    - alert: NginxIngressPodPending-default-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"nginx-ingress-default-controller-.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressPodPending-modsec-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"nginx-ingress-modsec.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressPodPending-production-only-ingress
+      annotations:
+        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
+          1 or more nginx-ingress pods have been unavailable for 5 minutes'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
+      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"nginx-ingress-production-only.*"})>
+        0
+      for: 5m
+      labels:
+        severity: warning
+
+    - alert: NginxIngressSuccessRate-default-ingress
+      annotations:
+        message: 'Percentage of successful requests of nginx-default over the last 5 minutes is less than 95%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 95
+      for: 5m
+      labels:
+        severity: warning
+    - alert: NginxIngressSuccessRate-modsec-ingress
+      annotations:
+        message: 'Percentage of successful requestsof nginx-modsec  over the last 5 minutes is less than 95%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 < 95
+      for: 5m
+      labels:
+        severity: warning

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -57,80 +57,7 @@ spec:
         severity: critical
       annotations:
         message: '{{ $labels.instance }} has high memory usage for than 5 minutes. Instance {{ $labels.instance }} memory has critically high usage.'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#memory-critical 
-    - alert: External-DNSDown
-      expr: kube_deployment_status_replicas_available{deployment="external-dns"} == 0
-      for: 5m
-      labels:
-        severity: warning
-      annotations: 
-        message: external-dns container has not been running in the namespace 'kube-system' for 5 minutes.
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#kubednsdown
-    - alert: NginxIngressPodDown-default-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-acme-controller-.*"})>
-        0
-      for: 5m
-      labels:
-        severity: warning
-
-    - alert: NginxIngressPodDown-modsec-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"modsec01.*"})>
-        0
-      for: 5m
-      labels:
-        severity: warning
-
-    - alert: NginxIngressDown-default-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"nginx-ingress-acme-controller-.*"})>
-        5
-      for: 5m
-      labels:
-        severity: critical
-
-    - alert: NginxIngressDown-modsec-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(namespace) (kube_pod_status_phase{namespace="ingress-controllers",phase="Failed",pod=~"modsec01.*"})>
-        3
-      for: 5m
-      labels:
-        severity: critical
-
-    - alert: NginxIngressPodPending-default-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"nginx-ingress-acme-controller-.*"})>
-        0
-      for: 5m
-      labels:
-        severity: warning
-
-    - alert: NginxIngressPodPending-modsec-ingress
-      annotations:
-        message: '{{ $labels.pod}} pod unavailable in the {{ $labels.namespace}} namespace.
-          1 or more nginx-ingress pods have been unavailable for 5 minutes'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginxingresspoddown
-      expr: sum by(pod) (kube_pod_status_phase{namespace="ingress-controllers",phase=~"Pending|Unknown",pod=~"modsec01.*"})>
-        0
-      for: 5m
-      labels:
-        severity: warning
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#memory-critical
 
     - alert: RootVolUtilisation-High
       expr: (node_filesystem_size_bytes {mountpoint="/"} - node_filesystem_avail_bytes {mountpoint="/"} ) / (node_filesystem_size_bytes {mountpoint="/"} ) * 100 >90
@@ -148,47 +75,6 @@ spec:
       annotations:
         message: '{{ $labels.instance }} has exceeded the threshold of root volume utilisation with a value of {{ $value }}. Instance {{ $labels.instance }} root volume utilisation usage is critically high'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#root-volume-utilisation---critical
-    - alert: NginxIngress-Latency(ms)-modsec-ingress-High
-      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"modsec01.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"modsec01.*"}[5m])) * 1000 > 300
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        message: '{{ $labels.pod}} - modsec01 ingress -latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
-    - alert: NginxIngress-Latency(ms)-nginx-ingress-acme-ingress-High
-      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"nginx-ingress-acme.*"}[5m])) * 1000 > 300
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        message: '{{ $labels.pod}} - nginx-ingress-acme ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
-    - alert: NginxIngress-Latency(ms)-k8snginx-ingress-High
-      expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_sum{ingress=~".*",pod=~"k8snginx.*"}[5m])) / sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds_count{ingress=~".*",pod=~"k8snginx.*"}[5m])) * 1000 > 300
-      for: 5m
-      labels:
-        severity: warning
-      annotations:
-        message: '{{ $labels.pod}} - k8snginx ingress ---latency delays are on the high side, with a value of {{ $value }} {{ $labels.namespace}} namespace. Please investigate'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#NginxIngress-Latency(ms)---warning
-
-    - alert: NginxConfigReloadFailureWarning
-      annotations:
-        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-config-reload-failure
-      expr: nginx_ingress_controller_config_last_reload_successful == 0
-      for: 3m
-      labels:
-        severity: warning
-    - alert: NginxConfigReloadFailure
-      annotations:
-        message: The Nginx Config has failed to reload for pod {{ $labels.pod }}
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-config-reload-failure:x
-      expr: nginx_ingress_controller_config_last_reload_successful == 0
-      for: 5m
-      labels:
-        severity: critical
     - alert: IncreaseInNodeCount
       annotations:
         message: 'The Node count has increased from {{ with query "count(node_uname_info offset 135s)" }}


### PR DESCRIPTION
- Seperate nginx ingress controller related alerts to seperate Prometheus rule
- Fix ingress-controller queries to match the correct controller pod names
- Add alerts for production-only ingress 
- add new alert to measure ingress controller success rate - Related to: https://github.com/ministryofjustice/cloud-platform/issues/4886
