### PR TITLE
Adjust success rate alert to trigger for over 10m

### DIFF
--- a/resources/prometheusrule-alerts/nginx-alerts.yaml
+++ b/resources/prometheusrule-alerts/nginx-alerts.yaml
@@ -150,21 +150,21 @@ spec:
 
     - alert: NginxIngressSuccessRate-default-ingress
       annotations:
-        message: 'Percentage of successful requests of nginx-default over the last 5 minutes is less than 95%.
+        message: 'Percentage of successful requests of nginx-default over the last 10 minutes is less than 95%.
           NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
       expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
         sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 95
-      for: 5m
+      for: 10m
       labels:
         severity: warning
     - alert: NginxIngressSuccessRate-modsec-ingress
       annotations:
-        message: 'Percentage of successful requestsof nginx-modsec  over the last 5 minutes is less than 95%.
+        message: 'Percentage of successful requestsof nginx-modsec  over the last 10 minutes is less than 95%.
           NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
       expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
         sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 < 95
-      for: 5m
+      for: 10m
       labels:
         severity: warning


### PR DESCRIPTION
This PR update the duration of success rate alert so it triggers of the rule condition persists over 10 minutes.

Having it as 5m is too sensitive and we get alerts when there is even a small minute blip.

Related to alert: https://mojdt.slack.com/archives/C8QR5FQRX/p1718277100533999 and https://mojdt.slack.com/archives/C8QR5FQRX/p1718277010938879
