### PR TITLE
feat: 🎸 dedup series from the thanos compactor

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -61,6 +61,8 @@ ruler:
 
 compactor:
   enabled:  ${enabled_compact}
+  extraFlags:
+    - --deduplication.replica-label="prometheus_replica"
   retentionResolutionRaw: 30d
   retentionResolution5m: 183d
   retentionResolution1h: 365d


### PR DESCRIPTION
This is to test whether the compactor can dedup prom metrics pulled from a test cluster

https://thanos.manager.cloud-platform.service.justice.gov.uk/graph?g0.expr=kube_pod_container_info%7Bnamespace%3D%22starter-pack-0%22%2C%20container%3D~%22helloworld.*%22%2C%20clusterName%3D%22cp-1706-0722%22%7D&g0.tab=0&g0.stacked=1&g0.range_input=6h&g0.max_source_resolution=0s&g0.deduplicate=0&g0.partial_response=0&g0.store_matches=%5B%5D&g0.engine=thanos&g0.analyze=0

see here for info on the flag and background on vertical compaction https://thanos.io/tip/components/compact.md/#vertical-compactions