### PR TITLE
⬆️  metrics-server helm chart upgrade 3.12.1

### DIFF
--- a/metrics-server.tf
+++ b/metrics-server.tf
@@ -4,7 +4,7 @@ resource "helm_release" "metrics_server" {
   chart      = "metrics-server"
   repository = "https://kubernetes-sigs.github.io/metrics-server/"
   namespace  = "kube-system"
-  version    = "3.8.3"
+  version    = "3.12.1"
 
   values = [templatefile("${path.module}/templates/metrics-server.yaml.tpl", {
   })]


### PR DESCRIPTION
This PR bumps the `metrics-server` helm chart from `3.8.1` > `3.12.1` (App version `0.6.2` > `0.7.1`)

Have tested on test cluster and working fine with no breaking changes.

Related to issue [Container image upgrade](https://github.com/ministryofjustice/cloud-platform/issues/5694)