### PR TITLE
chore: 🤖 bump timeout for query

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -32,8 +32,10 @@ query:
       cpu: 10m
       memory: 100Mi
 
-  ## @param query.replicaLabel Replica indicator(s) along which data is de-duplicated
+  extraFlags:
+    - --query.timeout=5m
 
+  ## @param query.replicaLabel Replica indicator(s) along which data is de-duplicated
   replicaLabel:
     - prometheus_replica
 

--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -47,11 +47,11 @@ query:
 queryFrontend:
   resources:
     limits:
-      cpu: 1600m
-      memory: 24Gi
+      cpu: 2000m
+      memory: 38Gi
     requests:
-      cpu: 10m
-      memory: 100Mi
+      cpu: 800m
+      memory: 12Gi
 
 
 ruler:


### PR DESCRIPTION
https://thanos.io/tip/components/query.md/#flags

- increase timeout to 5m
- and increase resource requests/ limits to cope with OOMKilled

```
    Last State:     Terminated
      Reason:       OOMKilled
      Exit Code:    137
      Started:      Fri, 23 Aug 2024 14:11:34 +0100
      Finished:     Fri, 23 Aug 2024 14:15:37 +0100
    Ready:          True
    Restart Count:  9
    Limits:
      cpu:     1600m
      memory:  24Gi
    Requests:
      cpu:        10m
      memory:     100Mi

```