### PR TITLE
chore: 🤖 bump mem limit thanos storegateway

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -7,7 +7,7 @@ storegateway:
   resources:
     limits:
       cpu: 1600m
-      memory: 24Gi
+      memory: 32Gi
     requests:
       cpu: 10m
       memory: 100Mi


### PR DESCRIPTION
We are seeing OOMKilled on this pod when we do big queries via thanos (the query will then fail)

https://grafana.live.cloud-platform.service.justice.gov.uk/d/6581e46e4e5c7ba40a07646395ef7b23/kubernetes-compute-resources-pod?var-datasource=default&var-cluster=&var-namespace=monitoring&var-pod=thanos-storegateway-0&orgId=1&refresh=10s&from=now-3h&to=now