### PR TITLE
chore: 🤖 bump storegateway cpu

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -6,7 +6,7 @@ metrics:
 storegateway:
   resources:
     limits:
-      cpu: 1600m
+      cpu: 2000m
       memory: 32Gi
     requests:
       cpu: 10m


### PR DESCRIPTION
- we are hitting cpu limits when doing large thanos queries