### PR TITLE
perf: ⚡️ prepare for downsampling phase of the compactor

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -75,11 +75,12 @@ compactor:
     - --deduplication.replica-label=prometheus_replica
     - --deduplication.func=penalty
     - --compact.concurrency=64
+    - --downsampling.concurrency=64
     - --compact.blocks-fetch-concurrency=16
     - --delete-delay=12h
     - --no-debug.halt-on-error
-  retentionResolutionRaw: 30d
-  retentionResolution5m: 183d
+  retentionResolutionRaw: 48h
+  retentionResolution5m: 14d
   retentionResolution1h: 365d
   persistence:
     size: 1000Gi

--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -79,8 +79,9 @@ compactor:
     - --compact.blocks-fetch-concurrency=16
     - --delete-delay=12h
     - --no-debug.halt-on-error
-  retentionResolutionRaw: 48h
-  retentionResolution5m: 14d
+    - --wait
+  retentionResolutionRaw: 30d
+  retentionResolution5m: 183d
   retentionResolution1h: 365d
   persistence:
     size: 1000Gi

--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -81,7 +81,7 @@ compactor:
     - --no-debug.halt-on-error
     - --wait
   retentionResolutionRaw: 30d
-  retentionResolution5m: 183d
+  retentionResolution5m: 180d
   retentionResolution1h: 365d
   persistence:
     size: 1000Gi


### PR DESCRIPTION
- once the compactor is finished with the backlog it will move on to downsampling
- set sensible downsampling values
- add wait flag

Below you can see once compactions backlog hit 0, the compactor just stopped, once it started again (green) it started compacting.
![image](https://github.com/user-attachments/assets/e9451d8f-4575-4a4b-88f9-95f4195db3c9)


https://thanos.io/tip/components/compact.md/#downsampling
https://thanos.io/tip/operating/compactor-backlog.md/#detect-the-backlog