### PR TITLE
perf: ⚡️ bump vol size

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -83,7 +83,7 @@ compactor:
   retentionResolution5m: 180d
   retentionResolution1h: 365d
   persistence:
-    size: 2000Gi
+    size: 4000Gi
   serviceAccount:
     create: false
     name: "${prometheus_sa_name}"


### PR DESCRIPTION
- downsample is pushing the baseline of files in vol up and then we are hitting the limit and causing compactor restarts