### PR TITLE
Subnet exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ module "monitoring" {
 | <a name="module_iam_assumable_role_yace_cloudwatch_exporter"></a> [iam\_assumable\_role\_yace\_cloudwatch\_exporter](#module\_iam\_assumable\_role\_yace\_cloudwatch\_exporter) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.24.1 |
 | <a name="module_irsa"></a> [irsa](#module\_irsa) | github.com/ministryofjustice/cloud-platform-terraform-irsa | 2.0.0 |
 | <a name="module_rds_exporter_irsa"></a> [rds\_exporter\_irsa](#module\_rds\_exporter\_irsa) | github.com/ministryofjustice/cloud-platform-terraform-irsa | 2.0.0 |
+| <a name="module_subnet_exporter_irsa"></a> [subnet\_exporter\_irsa](#module\_subnet\_exporter\_irsa) | github.com/ministryofjustice/cloud-platform-terraform-irsa | 2.0.0 |
 
 ## Resources
 
@@ -64,6 +65,7 @@ module "monitoring" {
 | [aws_iam_policy.grafana_datasource](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.rds_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.subnet_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.yace_cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_role.grafana_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role_policy_attachment.custom](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
@@ -73,6 +75,7 @@ module "monitoring" {
 | [helm_release.prometheus_operator_eks](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.prometheus_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.rds_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.subnet_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.thanos](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.thanos_proxy](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.yace_cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
@@ -98,6 +101,7 @@ module "monitoring" {
 | [aws_iam_policy_document.grafana_datasource_irsa](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.monitoring](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.rds_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.subnet_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.yace_cloudwatch_exporter](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
@@ -117,6 +121,7 @@ module "monitoring" {
 | <a name="input_enable_large_nodesgroup"></a> [enable\_large\_nodesgroup](#input\_enable\_large\_nodesgroup) | Due to Prometheus resource consumption, enabling this will set k8s Prometheus resources to higher values | `bool` | `false` | no |
 | <a name="input_enable_prometheus_affinity_and_tolerations"></a> [enable\_prometheus\_affinity\_and\_tolerations](#input\_enable\_prometheus\_affinity\_and\_tolerations) | Enable or not Prometheus node affinity (check helm values for the expressions) | `bool` | `false` | no |
 | <a name="input_enable_rds_exporter"></a> [enable\_rds\_exporter](#input\_enable\_rds\_exporter) | Whether or not to enable the RDS exporter | `bool` | `false` | no |
+| <a name="input_enable_subnet_exporter"></a> [enable\_subnet\_exporter](#input\_enable\_subnet\_exporter) | Whether or not to enable the Subnet exporter | `bool` | `false` | no |
 | <a name="input_enable_thanos_compact"></a> [enable\_thanos\_compact](#input\_enable\_thanos\_compact) | Enable or not Thanos Compact - not semantically concurrency safe and must be deployed as a singleton against a bucket | `bool` | `false` | no |
 | <a name="input_enable_thanos_helm_chart"></a> [enable\_thanos\_helm\_chart](#input\_enable\_thanos\_helm\_chart) | Enable or not Thanos Helm Chart - (do NOT confuse this with thanos sidecar within prometheus-operator) | `bool` | `false` | no |
 | <a name="input_enable_thanos_sidecar"></a> [enable\_thanos\_sidecar](#input\_enable\_thanos\_sidecar) | Enable or not Thanos sidecar. Basically defines if we want to send cluster metrics to thanos's S3 bucket | `bool` | `false` | no |

--- a/locals.tf
+++ b/locals.tf
@@ -32,6 +32,8 @@ locals {
 
   rds_exporter_sa = "rds-exporter"
 
+  subnet_exporter_sa = "subnet-exporter"
+
   alertmanager_receivers = [
     for receiver in var.alertmanager_slack_receivers : templatefile("${path.module}/templates/alertmanager_receivers.tpl", {
       severity = receiver.severity

--- a/subnet-exporter.tf
+++ b/subnet-exporter.tf
@@ -1,0 +1,82 @@
+resource "helm_release" "subnet_exporter" {
+  count = var.enable_subnet_exporter ? 1 : 0
+
+  name       = "subnet-exporter"
+  namespace  = kubernetes_namespace.monitoring.id
+  chart      = "aws-subnet-exporter"
+  version    = "0.1.5"
+  repository = "https://ministryofjustice.github.io/cloud-platform-helm-charts/"
+
+  set {
+    name  = "awsSubnetExporter.region"
+    value = "eu-west-2"
+  }
+
+  set {
+    name  = "awsSubnetExporter.filter"
+    value = "*"
+  }
+  
+  set {
+    name  = "serviceAccount.create"
+    value = false
+  }
+
+  set {
+    name  = "serviceAccount.name"
+    value = local.subnet_exporter_sa
+  }
+
+  set {
+    name = "serviceMonitor.enabled"
+    value = true
+  }
+
+  depends_on = [
+    local.prometheus_dependency,
+  ]
+
+  lifecycle {
+    ignore_changes = [keyring]
+  }
+}
+
+data "aws_iam_policy_document" "subnet_exporter" {
+statement {
+    sid    = "AllowDescribeSubnets"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeSubnets",
+      "ec2:DescribeTags",
+    ]
+    resources = [
+      "*",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "subnet_exporter" {
+  count = var.enable_subnet_exporter ? 1 : 0
+
+  name_prefix = "subnet_exporter"
+  description = "AWS subnet exporter policy for cluster ${var.cluster_domain_name}"
+  policy      = data.aws_iam_policy_document.subnet_exporter.json
+}
+
+module "subnet_exporter_irsa" {
+  count            = var.enable_subnet_exporter ? 1 : 0
+  source           = "github.com/ministryofjustice/cloud-platform-terraform-irsa?ref=2.0.0"
+  eks_cluster_name = terraform.workspace
+  namespace        = kubernetes_namespace.monitoring.id
+  role_policy_arns = {
+    irsa = aws_iam_policy.subnet_exporter[0].arn
+  }
+  service_account_name = local.subnet_exporter_sa
+
+  business_unit          = var.business_unit
+  application            = var.application
+  is_production          = var.is_production
+  team_name              = var.team_name
+  environment_name       = var.environment
+  infrastructure_support = var.infrastructure_support
+}

--- a/variables.tf
+++ b/variables.tf
@@ -128,3 +128,9 @@ variable "enable_rds_exporter" {
   default     = false
   type        = bool
 }
+
+variable "enable_subnet_exporter" {
+  description = "Whether or not to enable the Subnet exporter"
+  default     = false
+  type        = bool
+}


### PR DESCRIPTION
This PR adds aws-subnet-exporter to our monitoring stack, for subnet ip address availability metrics

[Repo](https://github.com/ministryofjustice/aws-subnet-exporter)

[Helm chart](https://github.com/ministryofjustice/cloud-platform-helm-charts/tree/main/aws-subnet-exporter)