### PR TITLE
alert for Node NotReady status

### DIFF
--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -101,6 +101,6 @@ spec:
         message: 'The Node is in a state of NotReady, investigate further'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
       expr: (kube_node_status_condition{condition="Ready", status="true"})
-      for: 1m
+      for: 15m
       labels:
         severity: warning

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -95,3 +95,12 @@ spec:
       for: 15s
       labels:
         severity: info-warning
+    node-alerts.yaml
+    - alert: NodeNotReadyState
+      annotations:
+        message: 'The Node is in a state of NotReady, investigate further'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: (kube_node_status_condition{condition="Ready", status="true"})
+      for: 1m
+      labels:
+        severity: warning


### PR DESCRIPTION
Add a new Prometheus alert for nodes which has a status of 'NotReady' state, as per the ticket https://github.com/orgs/ministryofjustice/projects/65/views/3?pane=issue&itemId=74458158&issue=ministryofjustice%7Ccloud-platform%7C6009

The query has been tested on a test cluster in Prometheseus
