### PR TITLE
perf: ⚡️ oomkilled on large queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ module "monitoring" {
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Issuer URL used to authenticate to Grafana, AlertManager and Prometheus (oauth2-proxy) | `any` | n/a | yes |
 | <a name="input_pagerduty_config"></a> [pagerduty\_config](#input\_pagerduty\_config) | Add PagerDuty key to allow integration with a PD service. | `any` | n/a | yes |
 | <a name="input_team_name"></a> [team\_name](#input\_team\_name) | n/a | `string` | `"webops"` | no |
+| <a name="input_thanos_query_replica_count"></a> [thanos\_query\_replica\_count](#input\_thanos\_query\_replica\_count) | the number of thanos query replicas | `number` | `1` | no |
 
 ## Outputs
 

--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -551,6 +551,10 @@ prometheus:
                   operator: In
                   values:
                   - prometheus-operator-kube-p-prometheus
+                - key: app.kubernetes.io/component
+                  operator: In
+                  values:
+                  - query
             topologyKey: topology.kubernetes.io/zone
 
     %{ endif ~}

--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -24,13 +24,43 @@ storegateway:
     - --min-time=-12w
 
 query:
+  replicaCount: "${thanos_query_replica_count}"
   resources:
     limits:
-      cpu: 1600m
-      memory: 24Gi
+      cpu: 3000m
+      memory: 45Gi
     requests:
       cpu: 10m
       memory: 100Mi
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: cloud-platform.justice.gov.uk/monitoring-ng
+            operator: In
+            values:
+            - "true"
+        - matchExpressions:
+          - key: topology.kubernetes.io/zone
+            operator: In
+            values:
+            - "eu-west-2a"
+            - "eu-west-2b"
+            - "eu-west-2c"
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchExpressions:
+              - key: app.kubernetes.io/instance
+                operator: In
+                values:
+                - prometheus-operator-kube-p-prometheus
+              - key: app.kubernetes.io/component
+                operator: In
+                values:
+                - query
+          topologyKey: topology.kubernetes.io/zone
 
   extraFlags:
     - --query.timeout=5m

--- a/thanos.tf
+++ b/thanos.tf
@@ -12,6 +12,7 @@ resource "helm_release" "thanos" {
     enabled_compact     = var.enable_thanos_compact
     monitoring_aws_role = module.iam_assumable_role_monitoring.iam_role_name
     clusterName         = terraform.workspace
+    thanos_query_replica_count = var.thanos_query_replica_count
   })]
 
   depends_on = [

--- a/variables.tf
+++ b/variables.tf
@@ -37,6 +37,12 @@ variable "enable_thanos_compact" {
   type        = bool
 }
 
+variable "thanos_query_replica_count" {
+  description = "the number of thanos query replicas"
+  default     = 1
+  type        = number
+}
+
 variable "enable_prometheus_affinity_and_tolerations" {
   description = "Enable or not Prometheus node affinity (check helm values for the expressions)"
   default     = false


### PR DESCRIPTION
- schedule in the monitoring group because it's so resource-hungry and can impact other services
- because the query can peak resources so high it makes sense to keep the query components separate so that they don't bring each other down
- increase replicas because it is [safe](https://thanos.io/v0.5/thanos/design.md/#scaling) for this component
- prevent thanos-query being deployed to a node which has prom on

![image](https://github.com/user-attachments/assets/40939456-091c-45c8-b77e-d57be0e22d78)
