### PR TITLE
perf: ⚡️ reduce time frame for alert

### DIFF
--- a/resources/manager_only_alerts.yaml
+++ b/resources/manager_only_alerts.yaml
@@ -12,7 +12,7 @@ spec:
     rules:
     - alert: ThanosCompactorCPUHigh
       annotations:
-        message: CPU throttling detected in the {{ $labels.namespace }} namespace. Please investigate and increase CPU limts if neccesary.
+        message: CPU throttling detected in the {{ $labels.namespace }} namespace. Please investigate and increase CPU limits if necessary.
           https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/241/files
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/pull/241/files
       expr: |-
@@ -26,7 +26,7 @@ spec:
         runbook_url: https://grafana.live.cloud-platform.service.justice.gov.uk/d/19fa341d-ae9d-4817-8a92-96b5df5ccd0a/thanos-overview?orgId=1&from=now-24h&to=now
       expr: |-
         sum(deriv(thanos_compact_todo_compactions[24h]) / 86400) > 0
-      for: 5m
+      for: 12h
       labels:
         severity: warning
 


### PR DESCRIPTION
- the compactor works slowly we only need to be notified if thanos compactor is going up and not coming back down over long periods. The compactor goes up and down as part of it's standard behaviour when working on backlogs.

![image](https://github.com/user-attachments/assets/25693237-d53b-43bc-93df-f925467405a1)
