### PR TITLE
feat: 🎸 scope alerts ingress policy to include thanos services

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,7 @@ resource "kubernetes_network_policy" "allow-monitoring-alerts" {
       match_expressions {
           key      = "app.kubernetes.io/name"
           operator = "In"
-          values   = ["prometheus", "alertmanager"]
+          values   = ["prometheus", "alertmanager", "thanos"]
         }
     }
     ingress {


### PR DESCRIPTION
This is to facilitate permitted cloud-platform services executing queries against thanos endpoints 