### PR TITLE
chore: 🤖 return prom loglevel to info

### DIFF
--- a/templates/prometheus-operator-eks.yaml.tpl
+++ b/templates/prometheus-operator-eks.yaml.tpl
@@ -420,7 +420,7 @@ prometheus:
   ## ref: https://github.com/coreos/prometheus-operator/blob/master/Documentation/api.md#prometheusspec
   ##
   prometheusSpec:
-    logLevel: debug
+    logLevel: info
     ## Number of replicas of each shard to deploy for a Prometheus deployment.
     ## Number of replicas multiplied by shards is the total number of Pods created.
     ##


### PR DESCRIPTION
this has been left in debug level since prometheus restart issue in nov 23.