### PR TITLE
chore: 🤖 add more nginx alerts

### DIFF
--- a/resources/prometheusrule-alerts/nginx-alerts.yaml
+++ b/resources/prometheusrule-alerts/nginx-alerts.yaml
@@ -138,21 +138,132 @@ spec:
 
     - alert: NginxIngressSuccessRate-default-ingress
       annotations:
-        message: 'Percentage of successful requests of nginx-default over the last 15 minutes is less than 95%.
+        message: 'Percentage of successful requests of nginx-default over the last 15 minutes is less than 90%.
           NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
-      expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
-        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 95
+      expr: sum(rate(nginx_ingress_controller_requests{status=~"[1-3].*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 90
       for: 15m
       labels:
         severity: warning
+
     - alert: NginxIngressSuccessRate-modsec-ingress
       annotations:
-        message: 'Percentage of successful requests of nginx-modsec  over the last 30 minutes is less than 95%.
+        message: 'Percentage of successful requests of nginx-modsec  over the last 15 minutes is less than 90%.
           NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
-      expr: sum(rate(nginx_ingress_controller_requests{status!~"[4-5].*", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
-        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 < 95
-      for: 30m
+      expr: sum(rate(nginx_ingress_controller_requests{status=~"[1-3].*", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 < 90
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress4xxRate-modsec-ingress
+      annotations:
+        message: 'Percentage of 4xx requests of nginx-modsec  over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: (sum(rate(nginx_ingress_controller_requests{status=~"4.*", controller_class=~"k8s.io/ingress-modsec"}[5m]))-sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m])))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress4xxRate-default-ingress
+      annotations:
+        message: 'Percentage of 4xx requests of nginx-default over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: (sum(rate(nginx_ingress_controller_requests{status=~"4.*", controller_class=~"k8s.io/ingress-default"}[5m]))-sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m])))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress5xxRate-modsec-ingress
+      annotations:
+        message: 'Percentage of 5xx requests of nginx-modsec  over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: sum(rate(nginx_ingress_controller_requests{status=~"5.*", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress5xxRate-default-ingress
+      annotations:
+        message: 'Percentage of 5xx requests of nginx-default over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: sum(rate(nginx_ingress_controller_requests{status=~"5.*", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress499Rate-modsec-ingress
+      annotations:
+        message: 'Percentage of 499 requests of nginx-modsec  over the last 15 minutes is more than 1%.
+          NOTE: Ignoring 404s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: sum(rate(nginx_ingress_controller_requests{status="499", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status="404", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 > 1
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress499Rate-default-ingress
+      annotations:
+        message: 'Percentage of 499 requests of nginx-default over the last 15 minutes is more than 1%.
+          NOTE: Ignoring 404s in this metric, since a  404 is a normal response for errant requests'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: sum(rate(nginx_ingress_controller_requests{status="499", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status="404", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 > 1
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress404Rate-modsec-ingress
+      annotations:
+        message: 'Percentage of 404 requests of nginx-modsec  over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 499s in this metric, since a  499 is a normal response when client closes the connection early eg. closed tab'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status="404", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status="499", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress404Rate-default-ingress
+      annotations:
+        message: 'Percentage of 404 requests of nginx-default over the last 15 minutes is more than 5%.
+          NOTE: Ignoring 499s in this metric, since a  499 is a normal response when client closes the connection early eg. closed tab'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status="404", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status="499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 > 5
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress200Rate-modsec-ingress
+      annotations:
+        message: 'Percentage of 200 requests of nginx-modsec over the last 15 minutes is less than 50%.
+          NOTE: Ignoring 404s and 499s in this metric, since a  499 is a normal response when client closes the connection early eg. closed tab'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status="200", controller_class=~"k8s.io/ingress-modsec"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-modsec"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"499|404", controller_class=~"k8s.io/ingress-modsec"}[5m]))) * 100 < 50
+      for: 15m
+      labels:
+        severity: warning
+
+    - alert: NginxIngress200Rate-default-ingress
+      annotations:
+        message: 'Percentage of 404 requests of nginx-default over the last 15 minutes is more than 10%.
+          NOTE: Ignoring 499s in this metric, since a  499 is a normal response when client closes the connection early eg. closed tab'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#nginx-success-rate
+      expr: sum(rate(nginx_ingress_controller_requests{status="200", controller_class=~"k8s.io/ingress-default"}[5m]))/(sum(rate(nginx_ingress_controller_requests{controller_class=~"k8s.io/ingress-default"}[5m]))-
+        sum(rate(nginx_ingress_controller_requests{status=~"404|499", controller_class=~"k8s.io/ingress-default"}[5m]))) * 100 < 50
+      for: 15m
       labels:
         severity: warning


### PR DESCRIPTION
- success rate alert flaps every night (this is real behaviour, we have less users in the middle of the night so the percentage of total requests which are successful are less), drop the threshold down to 90%
- add specific modsec and default percentage alerts for:
  - 4xx
  - 5xx
  - 404
  - 499
  - 200