### PR TITLE
Node scale alerts

### DIFF
--- a/resources/prometheusrule-alerts/README.md
+++ b/resources/prometheusrule-alerts/README.md
@@ -695,3 +695,30 @@ expr: sum by(pod)(rate(nginx_ingress_controller_ingress_upstream_latency_seconds
 ### Action
 
 Investigation in Kibana required
+
+## ChangeInNodeCountAlert
+```
+IncreaseInNodeCountAlert/DecreaseInNodeCountAlert
+Severity: warning
+```
+This alert is triggered when 3 or more nodes scale up/down within 30 minutes.  
+
+Expression:<br>
+Increase:
+```
+expr: count(node_uname_info) > (count(node_uname_info offset 1800s)+2)
+for: 15s
+```
+Decrease:
+```
+expr: count(node_uname_info) < (count(node_uname_info offset 1800s)-2)
+for: 15s
+```
+### Action
+
+Investigation the autoscaler logs what could have caused the scaling to trigger.
+
+```
+k get pods -n kube-system | grep cluster-autoscaler
+k logs -n kube-system cluster-autoscaler-...
+```

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -101,7 +101,7 @@ spec:
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
-      expr: count(node_uname_info) > (count(node_uname_info offset 1800s)+3)
+      expr: count(node_uname_info) > (count(node_uname_info offset 1800s)+2)
       for: 15s
       labels:
         severity: warning
@@ -111,7 +111,7 @@ spec:
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
-      expr: count(node_uname_info) < (count(node_uname_info offset 1800s)-3)
+      expr: count(node_uname_info) < (count(node_uname_info offset 1800s)-2)
       for: 15s
       labels:
         severity: warning

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -97,21 +97,21 @@ spec:
         severity: info-cloud-platform-notify
     - alert: IncreaseInNodeCountAlert
       annotations:
-        message: 'The Node count has increased an abnnormal amount from {{ with query "count(node_uname_info offset 3600s)" }}
+        message: 'The Node count has increased by 3 or more nodes within 30 minutes. From {{ with query "count(node_uname_info offset 1800s)" }}
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
-      expr: count(node_uname_info) > (count(node_uname_info offset 3600s)+5)
+      expr: count(node_uname_info) > (count(node_uname_info offset 1800s)+3)
       for: 15s
       labels:
         severity: warning
     - alert: DecreaseInNodeCountAlert
       annotations:
-        message: 'The Node count has decreased an abnnormal amount from {{ with query "count(node_uname_info offset 3600s)" }}
+        message: 'The Node count has decreased by 3 or more nodes within 30 minutes. From {{ with query "count(node_uname_info offset 1800s)" }}
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
         runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
-      expr: count(node_uname_info) < (count(node_uname_info offset 3600s)-5)
+      expr: count(node_uname_info) < (count(node_uname_info offset 1800s)-3)
       for: 15s
       labels:
         severity: warning

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -100,7 +100,7 @@ spec:
         message: 'The Node count has increased by 3 or more nodes within 30 minutes. From {{ with query "count(node_uname_info offset 1800s)" }}
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#ChangeInNodeCountAlert
       expr: count(node_uname_info) > (count(node_uname_info offset 1800s)+2)
       for: 15s
       labels:
@@ -110,7 +110,7 @@ spec:
         message: 'The Node count has decreased by 3 or more nodes within 30 minutes. From {{ with query "count(node_uname_info offset 1800s)" }}
           {{ . | first | value | humanize }}
         {{ end }} to {{ $value }}'
-        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md#ChangeInNodeCountAlert
       expr: count(node_uname_info) < (count(node_uname_info offset 1800s)-2)
       for: 15s
       labels:

--- a/resources/prometheusrule-alerts/node-alerts.yaml
+++ b/resources/prometheusrule-alerts/node-alerts.yaml
@@ -84,7 +84,7 @@ spec:
       expr: count(node_uname_info) > count(node_uname_info offset 135s)
       for: 15s
       labels:
-        severity: info-warning
+        severity: info-cloud-platform-notify
     - alert: DecreaseInNodeCount
       annotations:
         message: 'The Node count has decreased from {{ with query "count(node_uname_info offset 135s)" }}
@@ -94,7 +94,27 @@ spec:
       expr: count(node_uname_info) < count(node_uname_info offset 135s)
       for: 15s
       labels:
-        severity: info-warning
+        severity: info-cloud-platform-notify
+    - alert: IncreaseInNodeCountAlert
+      annotations:
+        message: 'The Node count has increased an abnnormal amount from {{ with query "count(node_uname_info offset 3600s)" }}
+          {{ . | first | value | humanize }}
+        {{ end }} to {{ $value }}'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: count(node_uname_info) > (count(node_uname_info offset 3600s)+5)
+      for: 15s
+      labels:
+        severity: warning
+    - alert: DecreaseInNodeCountAlert
+      annotations:
+        message: 'The Node count has decreased an abnnormal amount from {{ with query "count(node_uname_info offset 3600s)" }}
+          {{ . | first | value | humanize }}
+        {{ end }} to {{ $value }}'
+        runbook_url: https://github.com/ministryofjustice/cloud-platform-terraform-monitoring/blob/main/resources/prometheusrule-alerts/README.md
+      expr: count(node_uname_info) < (count(node_uname_info offset 3600s)-5)
+      for: 15s
+      labels:
+        severity: warning
     - alert: LowIpPrefixesAvailable
       annotations:
         message: The remaining available IP prefixes for the cluster is below 10% of it total availablity, {{ $value }} remaining. This must be addressed before no IP prefixes run out otherwise .


### PR DESCRIPTION
Move scale up and down notification to #lower-priority-alerts
Create new alert that will alert when 3 or more nodes scale up/down within 30 minutes
Create new entry in README for change in node count 

Done as a part of: [#6997](https://github.com/ministryofjustice/cloud-platform/issues/6997)
