### PR TITLE
chore: 🤖 set compact.concurrency to match available CPUs

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -111,7 +111,7 @@ compactor:
   retentionResolutionRaw: 30d
   retentionResolution5m: 180d
   retentionResolution1h: 365d
-  concurrency: 64
+  concurrency: 8
   persistence:
     size: 16000Gi
   serviceAccount:


### PR DESCRIPTION
## Why

To address high disk IO usage during compaction process (low priority alerts)

## What

It looks like our concurrency value is much higher than typically recommended.

Docs suggest setting no of goroutines here to equal no of CPUs:

https://thanos.io/tip/components/compact.md/#cpu

compactor node group is using [m6a.2xlarge](https://aws.amazon.com/ec2/instance-types/m6a/#:~:text=Up%20to%2010-,m6a.2xlarge,-8)

