### PR TITLE
chore: 🤖 pulling initContainer config to proxy chart

### DIFF
--- a/templates/oauth2-proxy.yaml.tpl
+++ b/templates/oauth2-proxy.yaml.tpl
@@ -109,3 +109,22 @@ priorityClassName: system-cluster-critical
 global:
   security:
     allowInsecureImages: true
+
+########################################
+# bitnami legacy image:
+# wait-for-redis initContainer 
+########################################
+
+initContainers:
+  # if the redis sub-chart is enabled, wait for it to be ready
+  # before starting the proxy
+  # creates a role binding to get, list, watch, the redis master pod
+  # if service account is enabled
+  waitForRedis:
+    enabled: true
+    image:
+      repository: "docker.io/bitnamilegacy/kubectl"
+      pullPolicy: "IfNotPresent"
+    # uses the kubernetes version of the cluster
+    # the chart is deployed on, if not set
+    kubectlVersion: ""


### PR DESCRIPTION
the proxy chart utilises a bitnami sourced kubectl image at redis startup time, we missed this because it was pretty much invisible...