### PR TITLE
chore: 🤖 reduce delete-delay 12hr to 2hr

### DIFF
--- a/templates/thanos-values.yaml.tpl
+++ b/templates/thanos-values.yaml.tpl
@@ -161,7 +161,7 @@ compactor:
     - --deduplication.func=penalty
     - --downsample.concurrency=16
     - --compact.blocks-fetch-concurrency=16
-    - --delete-delay=12h
+    - --delete-delay=2h
     - --no-debug.halt-on-error
   retentionResolutionRaw: 30d
   retentionResolution5m: 180d


### PR DESCRIPTION
## Purpose

This is an attempt to bring down our delete marked blocks, currently holding 2 thirds of total to sync:

```
thanos_compact_todo_deletion_blocks 6540
```

Following this (and other other subsequent tuning), we can watch this metric, and also

```
thanos_compact_iterations_total
```

relates to ministryofjustice/cloud-platform#8160




